### PR TITLE
feat: meter identifiers command

### DIFF
--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -15,7 +15,7 @@ import {
   toXmlDateString,
 } from "./types/xml";
 import fetch from "node-fetch";
-import { RequestInit, BodyInit } from "node-fetch";
+import { RequestInit, BodyInit, Response } from "node-fetch";
 import {
   IAccountAccountGetResponse,
   IAccountAccountPostResponse,
@@ -40,6 +40,16 @@ import { btoa } from "./functions";
 import { isNumber, isString } from "type-guards";
 import { isDate } from "util/types";
 import { deepmerge } from "deepmerge-ts";
+
+export class PortfolioManagerApiError extends Error {
+  constructor(public response: Response) {
+    super(response.statusText);
+  }
+}
+
+export function isPortfolioManagerApiError(obj: any): obj is PortfolioManagerApiError {
+  return obj instanceof PortfolioManagerApiError;
+}
 
 /**
  * Gateway to the the Portfolio Manager API.
@@ -75,7 +85,8 @@ export class PortfolioManagerApi {
         jpath ===
           "meterPropertyAssociationList.wasteMeterAssociation.meters.meterId" ||
         jpath === "meterData.meterDelivery" ||
-        jpath === "meterData.meterConsumption"
+        jpath === "meterData.meterConsumption" ||
+        jpath === "additionalIdentifiers.additionalIdentifier"
       );
     },
   };
@@ -117,7 +128,7 @@ export class PortfolioManagerApi {
     const response = await fetch(url, init);
     // raise exception on 400-599 status codes
     if (response.status >= 400 && response.status < 600) {
-      throw new Error(response.statusText);
+      throw new PortfolioManagerApiError(response);
     }
 
     const xmlResp = await response.text();

--- a/src/cli/PortfolioManagerMeterCommand.ts
+++ b/src/cli/PortfolioManagerMeterCommand.ts
@@ -1,6 +1,7 @@
 import { PortfolioManagerBaseCommand } from "./PortfolioManagerBaseCommand";
 import { PortfolioManagerMeterAssociationCommand } from "./PortfolioManagerMeterAssociationCommand";
 import { PortfolioManagerMeterConsumptionCommand } from "./PortfolioManagerMeterConsumptionCommand";
+import { PortfolioManagerMeterIdentifiersCommand } from "./PortfolioManagerMeterIdentifiersCommand";
 import { PortfolioManagerMeterListCommand } from "./PortfolioManagerMeterListCommand";
 
 export class PortfolioManagerMeterCommand extends PortfolioManagerBaseCommand {
@@ -9,5 +10,6 @@ export class PortfolioManagerMeterCommand extends PortfolioManagerBaseCommand {
     this.addCommand(new PortfolioManagerMeterAssociationCommand());
     this.addCommand(new PortfolioManagerMeterConsumptionCommand());
     this.addCommand(new PortfolioManagerMeterListCommand());
+    this.addCommand(new PortfolioManagerMeterIdentifiersCommand());
   }
 }

--- a/src/cli/PortfolioManagerMeterIdentifiersCommand.ts
+++ b/src/cli/PortfolioManagerMeterIdentifiersCommand.ts
@@ -1,0 +1,49 @@
+import { PortfolioManagerBaseCommand } from "./PortfolioManagerBaseCommand";
+
+export class PortfolioManagerMeterIdentifiersCommand extends PortfolioManagerBaseCommand {
+  _description = "Fetch additional identifiers for a meter.";
+  fields = ["@_id", "value", "description", "additionalIdentifierType.@_description"];
+  get examples() {
+    return [
+      "# customizing the output",
+      `${this.name} meter identifiers --meterId <meterId> --indent 2  --fields @_id @_hint`,
+      "",
+      "# using with JQ to map the output to shell scripting friendlier output",
+      `${this.name} meter identifiers --meterId <meterId> | jq -r  '[.[] | ."@_id"] | @sh'`,
+    ];
+  }
+  constructor() {
+    super("identifiers");
+    this.requiredOption(
+      "--meterId <meterId>",
+      "space seperated list of meter ids to fetch additional identifiers for"
+    )
+      .option("--myAccessOnly", "only fetch meters that I have access to")
+      .addFieldsOption(this.fields, ["@_id", "value", "description"]);
+  }
+
+  protected async _action(): Promise<void> {
+    const cmdOpts = this.opts();
+    console.error("meter identifiers", cmdOpts);
+    cmdOpts.fields.forEach((field: string) => {
+      this.fields.includes(field) ||
+        console.error(
+          `${field} is not a valid field, options: ${this.fields.join(", ")}`
+        );
+    });
+
+    const additionalIdentifiers = await this.getPortfolioManagerClient().getMeterAdditionalIdentifiers(cmdOpts.meterId);
+    const mapped = additionalIdentifiers.map((meter: Record<string, any>) => {
+      return cmdOpts.fields.reduce(
+        (acc: Record<string, any>, field: string) => {
+          acc[field] = meter[field];
+          return acc;
+        },
+        {}
+      );
+    });
+
+    const indent = cmdOpts.indent ? parseInt(cmdOpts.indent) || 2 : undefined;
+    console.log(JSON.stringify(mapped, null, indent));
+  }
+}


### PR DESCRIPTION
This command allows users to query additional identifiers for meters from the portfolio manager api. We've found them useful for embedding additional meta data about meters that are not available as fields in PM. 