### PR TITLE
test: Playwright-seeded connection/sharing e2e suite (+ plan)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,9 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run typecheck:e2e
       - run: npm run test:e2e
+      # Tracing starts after login (EspmWebUi), so no credentials appear in
+      # these artifacts; residual content is post-auth pages/session data for
+      # throwaway test-environment accounts.
       - name: Upload Playwright traces
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,42 @@
+name: E2E
+
+# Connection/sharing lifecycle against the shared ESPM test environment.
+# Runs nightly (and on demand) rather than per-PR: the suite drives the
+# pmtest web UI with Playwright, mutates shared stateful test accounts, and
+# is subject to upstream UI drift — see plans/connection-sharing-e2e-tests.md.
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+# The provider/peer test accounts are a shared singleton; runs must serialize.
+concurrency:
+  group: espm-test-env
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      PM_USERNAME: ${{ secrets.PM_USERNAME }}
+      PM_PASSWORD: ${{ secrets.PM_PASSWORD }}
+      PM_USERNAME2: ${{ secrets.PM_USERNAME2 }}
+      PM_PASSWORD2: ${{ secrets.PM_PASSWORD2 }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run typecheck:e2e
+      - run: npm run test:e2e
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-traces
+          path: test-results/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 env.*
 /.env.*
 /coverage/
+/test-results/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,12 @@ Notes:
   `npx tsx test/e2e/probe.ts contacts|add|connect|sharing|wsshare`. Use it
   to revalidate locators when the ESPM UI changes.
 - Set `E2E_HEADLESS=false` to watch the browser locally; failed runs write
-  Playwright traces to `test-results/e2e/` (inspect with
-  `npx playwright show-trace <file>.zip`).
+  Playwright traces to `test-results/e2e/` (override with `E2E_TRACE_DIR`;
+  inspect with `npx playwright show-trace <file>.zip`).
+- Endpoints are overridable for alternate environments: `PM_WEB_ENDPOINT`
+  (web UI, default `https://portfoliomanager.energystar.gov/pmtest`) and
+  `PM_ENDPOINT` (web services API, default
+  `https://portfoliomanager.energystar.gov/wstest/`).
 - UI locators live only in `test/e2e/EspmWebUi.ts`; when the ESPM UI changes,
   that file is the single place to fix.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,10 @@ Thanks for contributing to `portfolio-manager`.
 
 Environment variables used by tests:
 
-- `PM_USERNAME` (required)
+- `PM_USERNAME` (required) — web services provider test account (the account under test)
 - `PM_PASSWORD` (required)
+- `PM_USERNAME2` (e2e only) — persistent peer test account that initiates connections/shares
+- `PM_PASSWORD2` (e2e only)
 
 ## Local Workflow
 
@@ -51,6 +53,37 @@ We optimize for early detection of upstream Portfolio Manager API changes.
 - `npm test` is expected to run live API tests by default.
 - Test endpoint is fixed to `https://portfoliomanager.energystar.gov/wstest/`.
 - Required environment variables: `PM_USERNAME` and `PM_PASSWORD`.
+
+## End-to-End Connection & Sharing Tests
+
+ESPM's web services API cannot initiate connection or share requests — a
+standard user must do that through the web UI. The e2e suite
+(`test/e2e/`) drives the **peer account** (`PM_USERNAME2`/`PM_PASSWORD2`)
+through the test web UI (`https://portfoliomanager.energystar.gov/pmtest`)
+with Playwright to seed those requests, then exercises the SDK as the
+**provider account** (`PM_USERNAME`/`PM_PASSWORD`) against `wstest` to
+accept, verify, and clean up. Design and rationale live in
+`plans/connection-sharing-e2e-tests.md`.
+
+```bash
+npx playwright install chromium   # one-time browser download
+npm run typecheck:e2e
+npm run test:e2e
+```
+
+Notes:
+
+- The suite is excluded from `npm test`; it runs nightly in CI
+  (`.github/workflows/e2e.yml`) and serializes on the shared test accounts.
+- The peer account is a persistent, standard (non-provider) account in the
+  test environment. If EPA refreshes the test environment, recreate it via
+  the `pmtest` UI, make it searchable (Account Settings → Your Preferences),
+  and update the `PM_USERNAME2`/`PM_PASSWORD2` secrets.
+- Set `E2E_HEADLESS=false` to watch the browser locally; failed runs write
+  Playwright traces to `test-results/e2e/` (inspect with
+  `npx playwright show-trace <file>.zip`).
+- UI locators live only in `test/e2e/EspmWebUi.ts`; when the ESPM UI changes,
+  that file is the single place to fix.
 
 ## CI Source Of Truth
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,16 @@ Notes:
   (`.github/workflows/e2e.yml`) and serializes on the shared test accounts.
 - The peer account is a persistent, standard (non-provider) account in the
   test environment. If EPA refreshes the test environment, recreate it via
-  the `pmtest` UI, make it searchable (Account Settings → Your Preferences),
-  and update the `PM_USERNAME2`/`PM_PASSWORD2` secrets.
+  the `pmtest` UI and update the `PM_USERNAME2`/`PM_PASSWORD2` secrets.
+- The **provider** account must be searchable or the peer's contact search
+  finds nothing (Account Settings → Your Preferences → "Do you want your
+  username to be searchable..." → Yes). Already enabled; after an EPA test
+  environment refresh, re-apply with
+  `npx tsx test/e2e/probe.ts provider-settings --make-searchable`.
+- `test/e2e/probe.ts` is a selector-maintenance tool: it logs in and dumps
+  page structure (links, controls, dialogs) for each step of the flows, e.g.
+  `npx tsx test/e2e/probe.ts contacts|add|connect|sharing|wsshare`. Use it
+  to revalidate locators when the ESPM UI changes.
 - Set `E2E_HEADLESS=false` to watch the browser locally; failed runs write
   Playwright traces to `test-results/e2e/` (inspect with
   `npx playwright show-trace <file>.zip`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@types/node": "^25.3.5",
         "@vitest/coverage-v8": "^4.0.18",
+        "playwright": "^1.61.1",
         "semantic-release": "^25.0.3",
         "tsx": "^4.20.3",
         "typescript": "^5.9.3",
@@ -5844,6 +5845,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -11118,6 +11166,31 @@
           "dev": true
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true
     },
     "postcss": {
       "version": "8.5.8",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "typecheck:e2e": "tsc --noEmit -p tsconfig.e2e.json",
     "wipe:test-environment": "tsx ./scripts/wipeTestEnvironment.ts",
     "semantic-release": "semantic-release",
     "src-bin": "tsx ./src/index.ts",
@@ -34,6 +36,7 @@
   "devDependencies": {
     "@types/node": "^25.3.5",
     "@vitest/coverage-v8": "^4.0.18",
+    "playwright": "^1.61.1",
     "semantic-release": "^25.0.3",
     "tsx": "^4.20.3",
     "typescript": "^5.9.3",

--- a/plans/connection-sharing-e2e-tests.md
+++ b/plans/connection-sharing-e2e-tests.md
@@ -98,24 +98,30 @@ added value at this scale. Revisit if the UI-automation surface grows.
 
 - Add `playwright` to `devDependencies`; add `npx playwright install
   chromium` to CI and CONTRIBUTING setup notes.
-- New directory `test/e2e/`:
+- New directory `test/e2e/` (as built):
   - `test/e2e/EspmWebUi.ts` — page-object style helper around a Playwright
     `Page`: `login()`, `sendConnectionRequest(providerUsername)`,
-    `setupDataExchangeShare({ propertyNames, level })`, `logout()`.
-  - `test/e2e/seed.ts` — orchestration helpers combining SDK + UI:
-    `ensureCleanState()`, `seedConnectionRequest()`, `seedPropertyShare()`.
+    `setupDataExchangeShare({ propertyNames, accessLevel })`, `close()`.
+  - `test/e2e/support.ts` — env config plus orchestration helpers combining
+    SDK + UI: `ensureCleanProviderState()`, `disconnectIfConnected()`,
+    `ensurePeerFixtures()`, `waitFor()`.
+  - `test/e2e/probe.ts` / `test/e2e/state.ts` — selector-maintenance and
+    pending-state debug utilities.
 - Env vars: `PM_USERNAME2`, `PM_PASSWORD2` (persistent peer account), optional
   `PM_WEB_ENDPOINT` (default `https://portfoliomanager.energystar.gov/pmtest`),
-  `E2E_HEADLESS` (default true), `E2E_TRACE` (save trace on failure).
+  `E2E_HEADLESS` (default true), `E2E_TRACE_DIR` (trace output directory,
+  default `test-results/e2e`; traces are written on failure).
 
 ### 2. Fixture & state management
 
 - Fixture setup (SDK, peer creds against `wstest`): one property with one
-  electric meter, names prefixed `e2e-share-` + timestamp for correlation.
-- `ensureCleanState()` before each run, from the provider side (API only):
-  reject all pending connections/shares, `disconnect(accountId,
-  { keepShares: false })` for the peer account if connected. Peer
-  side: delete stale `e2e-share-*` fixture properties.
+  electric meter, fixed names (`E2E Share Fixture Property` / `E2E Share
+  Fixture Meter`) reused idempotently across runs via the `ensure*` helpers;
+  correlation happens through timestamped notes on accept/reject calls.
+- Clean state before each run, from the provider side (API only):
+  `ensureCleanProviderState()` rejects pending connections/shares from the
+  peer, and `disconnectIfConnected()` drops an established connection with
+  `keepShares: false`.
 - Extend `scripts/wipeTestEnvironment.ts` to also reject all pending
   connections/property/meter shares and disconnect all connected accounts, so
   `wipe:test-environment` returns the provider account to baseline.

--- a/plans/connection-sharing-e2e-tests.md
+++ b/plans/connection-sharing-e2e-tests.md
@@ -53,7 +53,7 @@ in `pmtest` shows up in `wstest` pending lists.
 | Role | Account | Credentials (env) | Purpose |
 |------|---------|-------------------|---------|
 | Provider (SUT) | existing web-services test account | `PM_USERNAME` / `PM_PASSWORD` | The account our SDK acts as; accepts/rejects via API. Must be searchable (Account Settings → Your Preferences → searchable = Yes). |
-| Consumer (seeder) | new standard test account | `PM_CONSUMER_USERNAME` / `PM_CONSUMER_PASSWORD` | Driven by Playwright in `pmtest`; owns fixture property + meters; initiates connections and shares. |
+| Peer (seeder) | persistent peer test account | `PM_USERNAME2` / `PM_PASSWORD2` | Long-lived peer account, driven by Playwright in `pmtest`; owns fixture property + meters; initiates connections and shares. |
 
 ### Runner choice: Playwright as a library inside vitest (recommended)
 
@@ -77,10 +77,12 @@ added value at this scale. Revisit if the UI-automation surface grows.
 
 ### 0. Spike / validate assumptions (do first, ~half day)
 
-- [ ] Create the consumer account manually in `pmtest`; record the procedure
-      in `CONTRIBUTING.md` (test env doesn't send real email; note security
-      questions and searchability settings).
-- [ ] Confirm the consumer account can call the `wstest` API with basic auth
+- [ ] Verify the persistent peer account (`PM_USERNAME2`) exists in the test
+      environment and log in to `pmtest` with it; document its setup and any
+      re-creation procedure in `CONTRIBUTING.md` in case EPA refreshes the
+      test environment (no real email delivery; note security questions and
+      searchability settings).
+- [ ] Confirm the peer account can call the `wstest` API with basic auth
       (used to create fixture property/meter via our own SDK instead of UI
       automation). Fallback: create fixtures through the UI with Playwright.
 - [ ] Manually walk the connect + share flows in `pmtest` against the provider
@@ -102,17 +104,17 @@ added value at this scale. Revisit if the UI-automation surface grows.
     `setupDataExchangeShare({ propertyNames, level })`, `logout()`.
   - `test/e2e/seed.ts` — orchestration helpers combining SDK + UI:
     `ensureCleanState()`, `seedConnectionRequest()`, `seedPropertyShare()`.
-- Env vars: `PM_CONSUMER_USERNAME`, `PM_CONSUMER_PASSWORD`, optional
+- Env vars: `PM_USERNAME2`, `PM_PASSWORD2` (persistent peer account), optional
   `PM_WEB_ENDPOINT` (default `https://portfoliomanager.energystar.gov/pmtest`),
   `E2E_HEADLESS` (default true), `E2E_TRACE` (save trace on failure).
 
 ### 2. Fixture & state management
 
-- Fixture setup (SDK, consumer creds against `wstest`): one property with one
+- Fixture setup (SDK, peer creds against `wstest`): one property with one
   electric meter, names prefixed `e2e-share-` + timestamp for correlation.
 - `ensureCleanState()` before each run, from the provider side (API only):
   reject all pending connections/shares, `disconnect(accountId,
-  { keepShares: false })` for the consumer account if connected. Consumer
+  { keepShares: false })` for the peer account if connected. Peer
   side: delete stale `e2e-share-*` fixture properties.
 - Extend `scripts/wipeTestEnvironment.ts` to also reject all pending
   connections/property/meter shares and disconnect all connected accounts, so
@@ -121,10 +123,10 @@ added value at this scale. Revisit if the UI-automation surface grows.
 ### 3. Integration spec
 
 `src/PortfolioManager.connectionSharing.e2e.spec.ts` (gated: skips unless
-provider + consumer creds are set), sequential lifecycle:
+provider + peer creds are set), sequential lifecycle:
 
 1. **Connection**: seed connection request via UI →
-   `getPendingConnections()` contains consumer account →
+   `getPendingConnections()` contains the peer account →
    `acceptConnection(accountId, note)` → pending list is empty.
 2. **Property share (accept)**: seed Exchange Data share of fixture property
    (bulk, Full Access) → `getPendingPropertyShares()` →
@@ -152,8 +154,7 @@ many requests), `SHAREUPDATE` notifications on permission edits.
   pattern for `*.e2e.spec.ts`); exclude `*.e2e.spec.ts` from the default
   `vitest run` so unit/CI runs stay fast and hermetic.
 - GitHub Actions: new `e2e` job/workflow.
-  - Secrets: `PM_USERNAME`, `PM_PASSWORD`, `PM_CONSUMER_USERNAME`,
-    `PM_CONSUMER_PASSWORD`.
+  - Secrets: `PM_USERNAME`, `PM_PASSWORD`, `PM_USERNAME2`, `PM_PASSWORD2`.
   - **Nightly schedule + manual dispatch**, not per-PR: the shared test
     environment is slow, rate-limited, and stateful; UI drift makes it flaky
     relative to PR signal.
@@ -182,7 +183,7 @@ many requests), `SHAREUPDATE` notifications on permission edits.
 
 ## Open questions
 
-1. Can the consumer (standard) test account call the `wstest` API for fixture
+1. Can the peer test account call the `wstest` API for fixture
    creation, or must fixtures be created through the UI? (spike)
 2. Does `pmtest` login present CAPTCHA/MFA for scripted browsers? (spike)
 3. Are Terms of Use / custom fields configured on the provider test account,

--- a/plans/connection-sharing-e2e-tests.md
+++ b/plans/connection-sharing-e2e-tests.md
@@ -75,24 +75,24 @@ added value at this scale. Revisit if the UI-automation surface grows.
 
 ## Work breakdown
 
-### 0. Spike / validate assumptions (do first, ~half day)
+### 0. Spike / validate assumptions — DONE (validated live 2026-07-04)
 
-- [ ] Verify the persistent peer account (`PM_USERNAME2`) exists in the test
-      environment and log in to `pmtest` with it; document its setup and any
-      re-creation procedure in `CONTRIBUTING.md` in case EPA refreshes the
-      test environment (no real email delivery; note security questions and
-      searchability settings).
-- [ ] Confirm the peer account can call the `wstest` API with basic auth
-      (used to create fixture property/meter via our own SDK instead of UI
-      automation). Fallback: create fixtures through the UI with Playwright.
-- [ ] Manually walk the connect + share flows in `pmtest` against the provider
-      account; capture selectors/labels and screenshots for the page objects.
-- [ ] Check for automation blockers on `pmtest` login: CAPTCHA, MFA, WAF
-      (Akamai) challenges, session idle timeouts. If login is blocked
-      headless, test headed/persistent-context; worst case, document a manual
-      seeding procedure and keep the API-side tests gated on pre-seeded state.
-- [ ] Confirm whether the provider account has Terms of Use / required custom
-      fields configured (changes the connect dialog the seeder must handle).
+- [x] Peer account (`PM_USERNAME2`) exists and logs in to `pmtest`.
+- [x] Peer account can call the `wstest` API with basic auth — fixtures are
+      created via the SDK (`ensureStandardProperties`/`ensureStandardMeterFixture`).
+- [x] Connect + share flows walked with `test/e2e/probe.ts`; selectors
+      captured in `test/e2e/EspmWebUi.ts`. Notable findings: pages hang on
+      the `load` event (wait for `domcontentloaded`), page content renders
+      via JS after load, contacts live at `/contact/list` (not `/contacts`),
+      and the share flow is an Angular app (`wsBulkSharing`,
+      `#modalDialogSelectProperties`).
+- [x] No CAPTCHA, MFA, or WAF blockers for headless Chromium login.
+- [x] Provider account had no Terms of Use / custom fields (no agreement
+      checkbox rendered). **Gotcha found:** the provider account was not
+      *searchable*, so the peer's contact search returned zero results.
+      Fixed via `npx tsx test/e2e/probe.ts provider-settings
+      --make-searchable` — a persistent account setting, re-apply after an
+      EPA test-environment refresh.
 
 ### 1. Dependencies & scaffolding
 

--- a/plans/connection-sharing-e2e-tests.md
+++ b/plans/connection-sharing-e2e-tests.md
@@ -1,0 +1,203 @@
+# Plan: End-to-End Connection & Sharing Tests (Playwright-seeded)
+
+Status: Draft
+Date: 2026-07-04
+Owner: Darrel O'Pry
+
+## Problem
+
+The connection and sharing client methods added in
+`feature/espm-account-connection-support` (`getPendingConnections`,
+`acceptConnection`, `rejectConnection`, `disconnect`,
+`getPendingPropertyShares`, `getPendingMeterShares`, accept/reject share,
+`unshareProperty`, `unshareMeter`) are currently only covered by mocked unit
+tests. They cannot be exercised against the live `wstest` environment because
+**ESPM's web services API is receive-only for connections and shares**: a
+provider can list pending requests and accept/reject them, but there is no API
+to *initiate* a connection request or a share. Initiation is done exclusively
+by a standard Portfolio Manager user through the web UI
+(`src/PortfolioManagerApi.ts` notes this: "Pending response wrappers depend on
+externally seeded requests in TEST").
+
+Per EPA's provider guidance ([Connection and Sharing for Data
+Exchange](https://portfoliomanager.energystar.gov/pdf/reference/Connection_and_Sharing_for_Data_Exchange_en_US.pdf),
+[How to Share Properties](https://www.energystar.gov/sites/default/files/2025-01/How%20to%20Share%20Properties%20with%20Other%20Portfolio%20Manager%20Users_December%202024.pdf)),
+the flow is:
+
+1. **User → UI**: adds the provider as a contact and sends a connection
+   request (Contacts → Add New Contacts/Connections → search by username →
+   Connect → accept Terms of Use → Send Connection Request).
+2. **Provider → API**: `GET /connect/account/pending/list`, then
+   `POST /connect/account/{accountId}` to accept/reject.
+3. **User → UI**: Sharing tab → **Set Up Web Services/Data Exchange** → select
+   provider → Select Properties → choose permissions (Bulk: Exchange Data
+   Full/Read Only/Custom) → **Authorize Exchange**.
+4. **Provider → API**: `GET /share/property/pending/list`,
+   `POST /share/property/{propertyId}`; same for meters via
+   `GET /share/meter/pending/list`, `POST /share/meter/{meterId}`.
+
+## Approach
+
+Use **Playwright to automate the "standard user" side** in the ESPM **test web
+UI** (`https://portfoliomanager.energystar.gov/pmtest`), seeding connection
+and share requests aimed at our web-services test account. The existing
+vitest integration suite then exercises the SDK (provider side) against
+`https://portfoliomanager.energystar.gov/wstest/` to accept/reject/verify, and
+cleans up.
+
+Both environments back onto the same test accounts/data, so a request created
+in `pmtest` shows up in `wstest` pending lists.
+
+### Two test accounts
+
+| Role | Account | Credentials (env) | Purpose |
+|------|---------|-------------------|---------|
+| Provider (SUT) | existing web-services test account | `PM_USERNAME` / `PM_PASSWORD` | The account our SDK acts as; accepts/rejects via API. Must be searchable (Account Settings → Your Preferences → searchable = Yes). |
+| Consumer (seeder) | new standard test account | `PM_CONSUMER_USERNAME` / `PM_CONSUMER_PASSWORD` | Driven by Playwright in `pmtest`; owns fixture property + meters; initiates connections and shares. |
+
+### Runner choice: Playwright as a library inside vitest (recommended)
+
+Use the `playwright` npm package (library, not `@playwright/test`) from within
+a vitest integration spec. Rationale:
+
+- Keeps a single test runner, config, and env-var gating convention
+  (`PM_USERNAME` checks already gate the live suite).
+- The lifecycle is inherently interleaved (UI seed → API accept → UI share →
+  API accept → API verify → API cleanup); one runner makes ordering explicit
+  in a single spec instead of coordinating two runners with global-setup
+  hand-offs.
+- We don't need `@playwright/test` fixtures/parallelism; tracing can be
+  enabled manually (`context.tracing.start()/stop()`) and saved on failure.
+
+Alternative considered: a separate `@playwright/test` project that imports the
+SDK for the API steps. Rejected for now — second runner/config/report for no
+added value at this scale. Revisit if the UI-automation surface grows.
+
+## Work breakdown
+
+### 0. Spike / validate assumptions (do first, ~half day)
+
+- [ ] Create the consumer account manually in `pmtest`; record the procedure
+      in `CONTRIBUTING.md` (test env doesn't send real email; note security
+      questions and searchability settings).
+- [ ] Confirm the consumer account can call the `wstest` API with basic auth
+      (used to create fixture property/meter via our own SDK instead of UI
+      automation). Fallback: create fixtures through the UI with Playwright.
+- [ ] Manually walk the connect + share flows in `pmtest` against the provider
+      account; capture selectors/labels and screenshots for the page objects.
+- [ ] Check for automation blockers on `pmtest` login: CAPTCHA, MFA, WAF
+      (Akamai) challenges, session idle timeouts. If login is blocked
+      headless, test headed/persistent-context; worst case, document a manual
+      seeding procedure and keep the API-side tests gated on pre-seeded state.
+- [ ] Confirm whether the provider account has Terms of Use / required custom
+      fields configured (changes the connect dialog the seeder must handle).
+
+### 1. Dependencies & scaffolding
+
+- Add `playwright` to `devDependencies`; add `npx playwright install
+  chromium` to CI and CONTRIBUTING setup notes.
+- New directory `test/e2e/`:
+  - `test/e2e/EspmWebUi.ts` — page-object style helper around a Playwright
+    `Page`: `login()`, `sendConnectionRequest(providerUsername)`,
+    `setupDataExchangeShare({ propertyNames, level })`, `logout()`.
+  - `test/e2e/seed.ts` — orchestration helpers combining SDK + UI:
+    `ensureCleanState()`, `seedConnectionRequest()`, `seedPropertyShare()`.
+- Env vars: `PM_CONSUMER_USERNAME`, `PM_CONSUMER_PASSWORD`, optional
+  `PM_WEB_ENDPOINT` (default `https://portfoliomanager.energystar.gov/pmtest`),
+  `E2E_HEADLESS` (default true), `E2E_TRACE` (save trace on failure).
+
+### 2. Fixture & state management
+
+- Fixture setup (SDK, consumer creds against `wstest`): one property with one
+  electric meter, names prefixed `e2e-share-` + timestamp for correlation.
+- `ensureCleanState()` before each run, from the provider side (API only):
+  reject all pending connections/shares, `disconnect(accountId,
+  { keepShares: false })` for the consumer account if connected. Consumer
+  side: delete stale `e2e-share-*` fixture properties.
+- Extend `scripts/wipeTestEnvironment.ts` to also reject all pending
+  connections/property/meter shares and disconnect all connected accounts, so
+  `wipe:test-environment` returns the provider account to baseline.
+
+### 3. Integration spec
+
+`src/PortfolioManager.connectionSharing.e2e.spec.ts` (gated: skips unless
+provider + consumer creds are set), sequential lifecycle:
+
+1. **Connection**: seed connection request via UI →
+   `getPendingConnections()` contains consumer account →
+   `acceptConnection(accountId, note)` → pending list is empty.
+2. **Property share (accept)**: seed Exchange Data share of fixture property
+   (bulk, Full Access) → `getPendingPropertyShares()` →
+   `acceptPropertyShare()` → verify real access: `getProperty(propertyId)` /
+   property metrics succeed from the provider account.
+3. **Meter share**: `getPendingMeterShares()` → accept → verify
+   `getMeter`/consumption access. Cover the documented coupling: accepting a
+   meter share auto-accepts the pending property share, while accepting a
+   property share does **not** auto-accept meter shares.
+4. **Reject path**: seed a second share → `rejectPropertyShare()` → pending
+   list empty, no access granted.
+5. **Unshare / disconnect**: `unshareProperty()` removes access;
+   `disconnect({ keepShares: false })` → connection gone; re-verify provider
+   has no residual access.
+6. Cleanup in `afterAll` (best-effort, mirrors `ensureCleanState`).
+
+Out of scope for v1 (note as future scenarios): share-forward/middleman
+(PDA vs `notificationCreatedByAccountId`), transfer of ownership, custom
+fields on connect/share, pending-list pagination (>1 page requires seeding
+many requests), `SHAREUPDATE` notifications on permission edits.
+
+### 4. npm scripts & CI
+
+- `"test:e2e": "vitest run --config vitest.e2e.config.ts"` (or an include
+  pattern for `*.e2e.spec.ts`); exclude `*.e2e.spec.ts` from the default
+  `vitest run` so unit/CI runs stay fast and hermetic.
+- GitHub Actions: new `e2e` job/workflow.
+  - Secrets: `PM_USERNAME`, `PM_PASSWORD`, `PM_CONSUMER_USERNAME`,
+    `PM_CONSUMER_PASSWORD`.
+  - **Nightly schedule + manual dispatch**, not per-PR: the shared test
+    environment is slow, rate-limited, and stateful; UI drift makes it flaky
+    relative to PR signal.
+  - `concurrency: { group: espm-test-env, cancel-in-progress: false }` —
+    the test accounts are a shared singleton; runs must serialize.
+  - Upload Playwright traces/screenshots as artifacts on failure.
+
+## Risks & mitigations
+
+- **UI drift**: ESPM ships releases ~2×/year and the UI may change without
+  notice. Isolate all selectors in `EspmWebUi.ts`; prefer role/label-based
+  locators over CSS; nightly runs surface drift quickly.
+- **EPA test-environment refreshes**: EPA periodically refreshes/wipes test
+  data. Seeding is idempotent and recreates fixtures from scratch; document
+  account re-creation in CONTRIBUTING.
+- **Anti-automation on login** (CAPTCHA/WAF): spike item 0. If blocking,
+  fall back to a documented manual seeding runbook + `wstest`-only assertions.
+- **Rate limits** on `wstest`: keep the suite small and serialized; back off
+  on 429s in the SDK test helpers.
+- **Shared-state flakiness**: timestamped fixture names + notes let us
+  correlate and clean stale artifacts from crashed runs; `ensureCleanState()`
+  makes reruns safe.
+- **Terms of use / propriety**: we are automating our *own* test accounts in
+  the environment EPA provides specifically for provider testing; keep
+  request volume minimal and off production.
+
+## Open questions
+
+1. Can the consumer (standard) test account call the `wstest` API for fixture
+   creation, or must fixtures be created through the UI? (spike)
+2. Does `pmtest` login present CAPTCHA/MFA for scripted browsers? (spike)
+3. Are Terms of Use / custom fields configured on the provider test account,
+   and do we want them configured to exercise that dialog path? (spike)
+4. Do we eventually want the seeder exposed as a CLI command
+   (`portfolio-manager test seed-shares`) for contributors without CI access?
+
+## References
+
+- EPA, *How to Use Web Services: Connection and Sharing Guidance for
+  Providers* — https://portfoliomanager.energystar.gov/pdf/reference/Connection_and_Sharing_for_Data_Exchange_en_US.pdf
+- EPA, *How to Share Properties with Other Portfolio Manager Users* (Dec 2024)
+  — https://www.energystar.gov/sites/default/files/2025-01/How%20to%20Share%20Properties%20with%20Other%20Portfolio%20Manager%20Users_December%202024.pdf
+- EPA, *Testing Web Services* —
+  https://portfoliomanager.energystar.gov/pdf/reference/Testing_Web_Services_en_US.pdf
+  (test UI: `…/pmtest`, test API: `…/wstest`)
+- Provider-side API surface: `src/PortfolioManagerApi.ts:506-604`,
+  client methods: `src/PortfolioManager.ts:694-860`.

--- a/plans/connection-sharing-e2e-tests.md
+++ b/plans/connection-sharing-e2e-tests.md
@@ -122,8 +122,9 @@ added value at this scale. Revisit if the UI-automation surface grows.
 
 ### 3. Integration spec
 
-`src/PortfolioManager.connectionSharing.e2e.spec.ts` (gated: skips unless
-provider + peer creds are set), sequential lifecycle:
+`test/e2e/connectionSharing.e2e.spec.ts` (run only via `npm run test:e2e`;
+fails fast with a clear error unless provider + peer creds are set, matching
+the repo's live-test convention), sequential lifecycle:
 
 1. **Connection**: seed connection request via UI →
    `getPendingConnections()` contains the peer account →

--- a/scripts/wipeTestEnvironment.ts
+++ b/scripts/wipeTestEnvironment.ts
@@ -180,6 +180,21 @@ async function main() {
     }
   }
 
+  let disconnectedAccounts = 0;
+  for (const customer of await pm.getCustomerList()) {
+    try {
+      await pm.disconnect(customer.id, { keepShares: false, note: wipeNote });
+      disconnectedAccounts++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      rejectErrors.push({
+        action: "disconnect",
+        id: customer.id,
+        error: message,
+      });
+    }
+  }
+
   const summary = {
     endpoint: args.endpoint,
     accountId,
@@ -189,6 +204,7 @@ async function main() {
     rejectedConnections,
     rejectedPropertyShares,
     rejectedMeterShares,
+    disconnectedAccounts,
     rejectErrors,
   };
 

--- a/scripts/wipeTestEnvironment.ts
+++ b/scripts/wipeTestEnvironment.ts
@@ -131,17 +131,70 @@ async function main() {
     }
   }
 
+  // Connections and shares are seeded externally (web UI) and accumulate in
+  // the shared test account; reject all pendings so runs start from baseline.
+  const wipeNote = "wipeTestEnvironment";
+  const authorizationErrors: Array<{ action: string; id: number; error: string }> =
+    [];
+  let rejectedPropertyShares = 0;
+  let rejectedMeterShares = 0;
+  let rejectedConnections = 0;
+
+  for (const share of await pm.getPendingPropertyShares()) {
+    try {
+      await pm.rejectPropertyShare(share.propertyId, wipeNote);
+      rejectedPropertyShares++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      authorizationErrors.push({
+        action: "rejectPropertyShare",
+        id: share.propertyId,
+        error: message,
+      });
+    }
+  }
+  for (const share of await pm.getPendingMeterShares()) {
+    try {
+      await pm.rejectMeterShare(share.id, wipeNote);
+      rejectedMeterShares++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      authorizationErrors.push({
+        action: "rejectMeterShare",
+        id: share.id,
+        error: message,
+      });
+    }
+  }
+  for (const connection of await pm.getPendingConnections()) {
+    try {
+      await pm.rejectConnection(connection.accountId, wipeNote);
+      rejectedConnections++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      authorizationErrors.push({
+        action: "rejectConnection",
+        id: connection.accountId,
+        error: message,
+      });
+    }
+  }
+
   const summary = {
     endpoint: args.endpoint,
     accountId,
     discoveredProperties: uniquePropertyIds.length,
     deletedProperties,
     propertyDeleteErrors,
+    rejectedConnections,
+    rejectedPropertyShares,
+    rejectedMeterShares,
+    authorizationErrors,
   };
 
   console.log(JSON.stringify(summary, null, 2));
 
-  if (propertyDeleteErrors.length > 0) {
+  if (propertyDeleteErrors.length > 0 || authorizationErrors.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/scripts/wipeTestEnvironment.ts
+++ b/scripts/wipeTestEnvironment.ts
@@ -134,7 +134,7 @@ async function main() {
   // Connections and shares are seeded externally (web UI) and accumulate in
   // the shared test account; reject all pendings so runs start from baseline.
   const wipeNote = "wipeTestEnvironment";
-  const authorizationErrors: Array<{ action: string; id: number; error: string }> =
+  const rejectErrors: Array<{ action: string; id: number; error: string }> =
     [];
   let rejectedPropertyShares = 0;
   let rejectedMeterShares = 0;
@@ -146,7 +146,7 @@ async function main() {
       rejectedPropertyShares++;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      authorizationErrors.push({
+      rejectErrors.push({
         action: "rejectPropertyShare",
         id: share.propertyId,
         error: message,
@@ -159,7 +159,7 @@ async function main() {
       rejectedMeterShares++;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      authorizationErrors.push({
+      rejectErrors.push({
         action: "rejectMeterShare",
         id: share.id,
         error: message,
@@ -172,7 +172,7 @@ async function main() {
       rejectedConnections++;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      authorizationErrors.push({
+      rejectErrors.push({
         action: "rejectConnection",
         id: connection.accountId,
         error: message,
@@ -189,12 +189,12 @@ async function main() {
     rejectedConnections,
     rejectedPropertyShares,
     rejectedMeterShares,
-    authorizationErrors,
+    rejectErrors,
   };
 
   console.log(JSON.stringify(summary, null, 2));
 
-  if (propertyDeleteErrors.length > 0 || authorizationErrors.length > 0) {
+  if (propertyDeleteErrors.length > 0 || rejectErrors.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -203,10 +203,11 @@ export class EspmWebUi {
         `No connected web services provider option matching '${options.providerUsername}' — is the connection accepted?`
       );
     }
+    const providerValue = await providerOption.getAttribute("value");
     await providerSelect.selectOption(
-      (await providerOption.getAttribute("value")) ?? {
-        label: (await providerOption.innerText()).trim(),
-      }
+      providerValue // blank value attribute would select the placeholder
+        ? providerValue
+        : { label: (await providerOption.innerText()).trim() }
     );
 
     // 2. Select Properties — opens the Angular picker dialog.

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -62,6 +62,10 @@ export class EspmWebUi {
       await this.context.tracing.start({ screenshots: true, snapshots: true });
     }
     this._page = await this.context.newPage();
+    // ESPM uses native confirm() dialogs (e.g. re-sharing when the contact
+    // already had access). Playwright dismisses dialogs by default, which
+    // silently cancels the action — accept them instead.
+    this._page.on("dialog", (dialog) => void dialog.accept());
   }
 
   /**
@@ -230,10 +234,33 @@ export class EspmWebUi {
 
     // 4. Send the sharing request. The button label flips between
     // "Authorize Exchange" (bulk) and "Set Permissions" (personalized).
+    // The page submits via XHR to /wsBulkSharing/authorizeExchange.json and
+    // swallows failures silently (its error handler just stops the spinner),
+    // so verify the actual response instead of the DOM. The endpoint has been
+    // observed taking minutes before answering when the test environment is
+    // degraded — hence the generous timeout.
+    const authorizeResponse = page
+      .waitForResponse(
+        (r) => r.url().includes("/wsBulkSharing/authorizeExchange.json"),
+        { timeout: 180000 }
+      )
+      .catch(() => undefined);
     await page
       .locator("button", { hasText: /authorize exchange/i })
       .first()
       .click();
-    await page.waitForLoadState("domcontentloaded");
+    const response = await authorizeResponse;
+    if (!response) {
+      throw new Error(
+        "No response from wsBulkSharing/authorizeExchange.json within 180s — " +
+          "the ESPM test environment is likely degraded."
+      );
+    }
+    if (response.status() !== 200) {
+      throw new Error(
+        `wsBulkSharing/authorizeExchange.json returned HTTP ${response.status()} — ` +
+          "ESPM test environment error while creating the share request."
+      );
+    }
   }
 }

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -1,4 +1,4 @@
-import { Browser, BrowserContext, Page, chromium } from "playwright";
+import { Browser, BrowserContext, Page, chromium, errors } from "playwright";
 
 /**
  * Page-object wrapper around the ENERGY STAR Portfolio Manager test web UI
@@ -244,7 +244,10 @@ export class EspmWebUi {
         (r) => r.url().includes("/wsBulkSharing/authorizeExchange.json"),
         { timeout: 180000 }
       )
-      .catch(() => undefined);
+      .catch((error) => {
+        if (error instanceof errors.TimeoutError) return undefined;
+        throw error;
+      });
     await page
       .locator("button", { hasText: /authorize exchange/i })
       .first()

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -65,7 +65,11 @@ export class EspmWebUi {
     // ESPM uses native confirm() dialogs (e.g. re-sharing when the contact
     // already had access). Playwright dismisses dialogs by default, which
     // silently cancels the action — accept them instead.
-    this._page.on("dialog", (dialog) => void dialog.accept());
+    this._page.on("dialog", (dialog) =>
+      dialog.accept().catch(() => {
+        // Page/context closed while the dialog was pending — nothing to do.
+      })
+    );
   }
 
   /**

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -9,10 +9,9 @@ import { Browser, BrowserContext, Page, chromium } from "playwright";
  * "Connection and Sharing Guidance for Providers" and "How to Share
  * Properties" documents — see plans/connection-sharing-e2e-tests.md.
  *
- * NOTE: Locators are written from EPA's documentation of the UI (button and
- * link labels) and still need a validation pass against the live pmtest UI
- * (plan spike item). Keep every selector in this file so drift is a
- * single-file fix.
+ * Locators were validated against the live pmtest UI on 2026-07-04 using
+ * test/e2e/probe.ts — rerun that tool to revalidate when the ESPM UI drifts.
+ * Keep every selector in this file so drift is a single-file fix.
  */
 
 export const DEFAULT_WEB_UI_URL =
@@ -186,16 +185,21 @@ export class EspmWebUi {
     // Option labels look like "Org Name (username)", so resolve the option
     // whose text contains the username instead of matching the label exactly.
     const providerSelect = page.locator("select").first();
-    const providerOption = await providerSelect
+    const providerOption = providerSelect
       .locator("option", { hasText: options.providerUsername })
-      .first()
-      .getAttribute("value");
-    if (providerOption === null) {
+      .first();
+    try {
+      await providerOption.waitFor({ state: "attached" });
+    } catch {
       throw new Error(
-        `No connected web services provider option matching '${options.providerUsername}'`
+        `No connected web services provider option matching '${options.providerUsername}' — is the connection accepted?`
       );
     }
-    await providerSelect.selectOption(providerOption);
+    await providerSelect.selectOption(
+      (await providerOption.getAttribute("value")) ?? {
+        label: (await providerOption.innerText()).trim(),
+      }
+    );
 
     // 2. Select Properties — opens the Angular picker dialog.
     await page.locator("#buttonSelectProperties").click();

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -58,9 +58,6 @@ export class EspmWebUi {
     // pmtest pages regularly stall on slow subresources; navigation waits for
     // domcontentloaded (see goto below) but still needs generous headroom.
     this.context.setDefaultNavigationTimeout(this.actionTimeoutMs * 2);
-    if (this.traceDir) {
-      await this.context.tracing.start({ screenshots: true, snapshots: true });
-    }
     this._page = await this.context.newPage();
     // ESPM uses native confirm() dialogs (e.g. re-sharing when the contact
     // already had access). Playwright dismisses dialogs by default, which
@@ -125,6 +122,13 @@ export class EspmWebUi {
       .getByRole("link", { name: /myportfolio/i })
       .first()
       .waitFor({ state: "visible" });
+
+    // Tracing starts only after authentication so credentials never appear
+    // in trace snapshots — traces are uploaded as CI artifacts, which are
+    // publicly downloadable on a public repository.
+    if (this.traceDir && this.context) {
+      await this.context.tracing.start({ screenshots: true, snapshots: true });
+    }
   }
 
   /**

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -1,0 +1,221 @@
+import { Browser, BrowserContext, Page, chromium } from "playwright";
+
+/**
+ * Page-object wrapper around the ENERGY STAR Portfolio Manager test web UI
+ * (https://portfoliomanager.energystar.gov/pmtest).
+ *
+ * The web services API is receive-only for connections and shares, so the
+ * peer account must initiate them through this UI. Flows follow EPA's
+ * "Connection and Sharing Guidance for Providers" and "How to Share
+ * Properties" documents — see plans/connection-sharing-e2e-tests.md.
+ *
+ * NOTE: Locators are written from EPA's documentation of the UI (button and
+ * link labels) and still need a validation pass against the live pmtest UI
+ * (plan spike item). Keep every selector in this file so drift is a
+ * single-file fix.
+ */
+
+export const DEFAULT_WEB_UI_URL =
+  "https://portfoliomanager.energystar.gov/pmtest";
+
+export type ExchangeDataAccessLevel = "Full Access" | "Read Only Access";
+
+export interface IEspmWebUiOptions {
+  baseUrl?: string;
+  headless?: boolean;
+  /** Directory to write a Playwright trace into on close(). */
+  traceDir?: string;
+  /** Per-action timeout in ms. The pmtest environment can be slow. */
+  actionTimeoutMs?: number;
+}
+
+export class EspmWebUi {
+  readonly baseUrl: string;
+  private readonly headless: boolean;
+  private readonly traceDir?: string;
+  private readonly actionTimeoutMs: number;
+  private browser?: Browser;
+  private context?: BrowserContext;
+  private _page?: Page;
+
+  constructor(options: IEspmWebUiOptions = {}) {
+    this.baseUrl = (options.baseUrl || DEFAULT_WEB_UI_URL).replace(/\/$/, "");
+    this.headless = options.headless ?? true;
+    this.traceDir = options.traceDir;
+    this.actionTimeoutMs = options.actionTimeoutMs ?? 30000;
+  }
+
+  get page(): Page {
+    if (!this._page) {
+      throw new Error("EspmWebUi not launched. Call launch() first.");
+    }
+    return this._page;
+  }
+
+  async launch(): Promise<void> {
+    this.browser = await chromium.launch({ headless: this.headless });
+    this.context = await this.browser.newContext();
+    this.context.setDefaultTimeout(this.actionTimeoutMs);
+    if (this.traceDir) {
+      await this.context.tracing.start({ screenshots: true, snapshots: true });
+    }
+    this._page = await this.context.newPage();
+  }
+
+  /**
+   * Stops tracing (writing the trace when a name is given) and closes the
+   * browser. Safe to call multiple times.
+   */
+  async close(traceName?: string): Promise<void> {
+    if (this.context && this.traceDir) {
+      try {
+        await this.context.tracing.stop(
+          traceName
+            ? { path: `${this.traceDir}/${traceName}.zip` }
+            : undefined
+        );
+      } catch {
+        // Tracing may already be stopped; never mask the test failure.
+      }
+    }
+    await this.browser?.close();
+    this.browser = undefined;
+    this.context = undefined;
+    this._page = undefined;
+  }
+
+  /** Logs in to the Portfolio Manager web UI. */
+  async login(username: string, password: string): Promise<void> {
+    const page = this.page;
+    await page.goto(`${this.baseUrl}/login`);
+    await page
+      .locator('input[name="username"], #username')
+      .first()
+      .fill(username);
+    await page
+      .locator('input[name="password"], #password')
+      .first()
+      .fill(password);
+    await page
+      .getByRole("button", { name: /sign in|log ?in/i })
+      .or(page.locator('input[type="submit"]'))
+      .first()
+      .click();
+    // MyPortfolio is the landing tab for an authenticated session.
+    await page
+      .getByRole("link", { name: /myportfolio/i })
+      .first()
+      .waitFor({ state: "visible" });
+  }
+
+  /**
+   * Sends a connection request to a provider account.
+   * UI path: Contacts -> Add New Contacts/Connections -> search by username
+   * -> Connect -> (accept Terms of Use if configured) -> Send Connection
+   * Request.
+   */
+  async sendConnectionRequest(providerUsername: string): Promise<void> {
+    const page = this.page;
+    await page.goto(`${this.baseUrl}/contacts`);
+    await page
+      .getByRole("link", { name: /add (new )?contacts?/i })
+      .or(page.getByRole("button", { name: /add (new )?contacts?/i }))
+      .first()
+      .click();
+
+    await page
+      .locator('input[name*="username" i], input[id*="username" i]')
+      .first()
+      .fill(providerUsername);
+    await page.getByRole("button", { name: /search/i }).first().click();
+
+    // Connect from the search-result row for the provider account.
+    const resultRow = page
+      .locator("tr", { hasText: providerUsername })
+      .or(page.locator("li", { hasText: providerUsername }));
+    await resultRow
+      .getByRole("button", { name: /^connect$/i })
+      .or(resultRow.getByRole("link", { name: /^connect$/i }))
+      .first()
+      .click();
+
+    // Providers may configure Terms of Use that must be acknowledged.
+    const agreement = page.locator('input[type="checkbox"]');
+    if (await agreement.count()) {
+      await agreement.first().check();
+    }
+    await page
+      .getByRole("button", { name: /send connection request/i })
+      .first()
+      .click();
+  }
+
+  /**
+   * Shares properties with a connected web services provider at the
+   * Exchange Data level.
+   * UI path: Sharing -> Set Up Web Services/Data Exchange -> select provider
+   * -> Select Properties -> Bulk Sharing (Exchange Data Full/Read Only
+   * Access) -> Authorize Exchange.
+   */
+  async setupDataExchangeShare(options: {
+    providerUsername: string;
+    propertyNames: string[];
+    accessLevel: ExchangeDataAccessLevel;
+  }): Promise<void> {
+    const page = this.page;
+    await page.goto(`${this.baseUrl}/sharing`);
+    await page
+      .getByRole("link", {
+        name: /set up web services|share .*data exchange|exchanging data/i,
+      })
+      .first()
+      .click();
+
+    // 1. Select Web Services Provider (Account) — dropdown of connections.
+    // Option labels look like "Org Name (username)", so resolve the option
+    // whose text contains the username instead of matching the label exactly.
+    const providerSelect = page.locator("select").first();
+    const providerOption = await providerSelect
+      .locator("option", { hasText: options.providerUsername })
+      .first()
+      .getAttribute("value");
+    if (providerOption === null) {
+      throw new Error(
+        `No connected web services provider option matching '${options.providerUsername}'`
+      );
+    }
+    await providerSelect.selectOption(providerOption);
+
+    // 2. Select Properties — opens a picker dialog.
+    await page
+      .getByRole("button", { name: /select properties/i })
+      .or(page.getByRole("link", { name: /select properties/i }))
+      .first()
+      .click();
+    for (const propertyName of options.propertyNames) {
+      await page
+        .locator("tr", { hasText: propertyName })
+        .locator('input[type="checkbox"]')
+        .first()
+        .check();
+    }
+    await page
+      .getByRole("button", { name: /apply selection/i })
+      .first()
+      .click();
+
+    // 3. Choose Permissions — bulk exchange-data access for everything.
+    await page
+      .getByText(
+        new RegExp(`exchange data ${options.accessLevel}`.replace(/ /g, "\\s+"), "i")
+      )
+      .first()
+      .click();
+
+    // 4. Send the sharing request.
+    await page
+      .getByRole("button", { name: /authorize exchange/i })
+      .first()
+      .click();
+  }
+}

--- a/test/e2e/EspmWebUi.ts
+++ b/test/e2e/EspmWebUi.ts
@@ -56,6 +56,9 @@ export class EspmWebUi {
     this.browser = await chromium.launch({ headless: this.headless });
     this.context = await this.browser.newContext();
     this.context.setDefaultTimeout(this.actionTimeoutMs);
+    // pmtest pages regularly stall on slow subresources; navigation waits for
+    // domcontentloaded (see goto below) but still needs generous headroom.
+    this.context.setDefaultNavigationTimeout(this.actionTimeoutMs * 2);
     if (this.traceDir) {
       await this.context.tracing.start({ screenshots: true, snapshots: true });
     }
@@ -84,10 +87,19 @@ export class EspmWebUi {
     this._page = undefined;
   }
 
+  /**
+   * Navigates waiting only for domcontentloaded: pmtest pages routinely
+   * stall on slow subresources, so waiting for the full load event times out
+   * even though the page is usable.
+   */
+  private async goto(url: string): Promise<void> {
+    await this.page.goto(url, { waitUntil: "domcontentloaded" });
+  }
+
   /** Logs in to the Portfolio Manager web UI. */
   async login(username: string, password: string): Promise<void> {
     const page = this.page;
-    await page.goto(`${this.baseUrl}/login`);
+    await this.goto(`${this.baseUrl}/login`);
     await page
       .locator('input[name="username"], #username')
       .first()
@@ -116,18 +128,15 @@ export class EspmWebUi {
    */
   async sendConnectionRequest(providerUsername: string): Promise<void> {
     const page = this.page;
-    await page.goto(`${this.baseUrl}/contacts`);
+    await this.goto(`${this.baseUrl}/contact/list`);
     await page
-      .getByRole("link", { name: /add (new )?contacts?/i })
-      .or(page.getByRole("button", { name: /add (new )?contacts?/i }))
+      .getByRole("button", { name: /add new contacts/i })
       .first()
       .click();
 
-    await page
-      .locator('input[name*="username" i], input[id*="username" i]')
-      .first()
-      .fill(providerUsername);
-    await page.getByRole("button", { name: /search/i }).first().click();
+    // "Connect with an Existing User for Sharing" search form.
+    await page.locator("#searchContactUsername").fill(providerUsername);
+    await page.getByRole("button", { name: /^search$/i }).first().click();
 
     // Connect from the search-result row for the provider account.
     const resultRow = page
@@ -139,15 +148,17 @@ export class EspmWebUi {
       .first()
       .click();
 
-    // Providers may configure Terms of Use that must be acknowledged.
-    const agreement = page.locator('input[type="checkbox"]');
-    if (await agreement.count()) {
+    // Lands on /dataexchange/sendConnectionRequest. The Terms of Use
+    // agreement checkbox only renders when the provider configured terms.
+    const agreement = page.locator('input[id^="agreement-checkbox"]');
+    if ((await agreement.count()) && (await agreement.first().isVisible())) {
       await agreement.first().check();
     }
     await page
       .getByRole("button", { name: /send connection request/i })
       .first()
       .click();
+    await page.waitForLoadState("domcontentloaded");
   }
 
   /**
@@ -163,7 +174,7 @@ export class EspmWebUi {
     accessLevel: ExchangeDataAccessLevel;
   }): Promise<void> {
     const page = this.page;
-    await page.goto(`${this.baseUrl}/sharing`);
+    await this.goto(`${this.baseUrl}/sharing`);
     await page
       .getByRole("link", {
         name: /set up web services|share .*data exchange|exchanging data/i,
@@ -186,36 +197,39 @@ export class EspmWebUi {
     }
     await providerSelect.selectOption(providerOption);
 
-    // 2. Select Properties — opens a picker dialog.
-    await page
-      .getByRole("button", { name: /select properties/i })
-      .or(page.getByRole("link", { name: /select properties/i }))
-      .first()
-      .click();
+    // 2. Select Properties — opens the Angular picker dialog.
+    await page.locator("#buttonSelectProperties").click();
+    const dialog = page.locator("#modalDialogSelectProperties");
+    await dialog.waitFor({ state: "visible" });
     for (const propertyName of options.propertyNames) {
-      await page
-        .locator("tr", { hasText: propertyName })
+      await dialog
+        .locator("#modalDialogSelectPropertiesTable tbody tr", {
+          hasText: propertyName,
+        })
         .locator('input[type="checkbox"]')
         .first()
         .check();
     }
-    await page
-      .getByRole("button", { name: /apply selection/i })
+    await dialog
+      .getByText(/apply selection/i)
       .first()
       .click();
+    await dialog.waitFor({ state: "hidden" });
 
     // 3. Choose Permissions — bulk exchange-data access for everything.
+    await page.locator('input[name="bulk"][value="yes"]').check();
+    const accessValue =
+      options.accessLevel === "Full Access" ? "FULL_ACCESS" : "READ_ONLY";
     await page
-      .getByText(
-        new RegExp(`exchange data ${options.accessLevel}`.replace(/ /g, "\\s+"), "i")
-      )
-      .first()
-      .click();
+      .locator(`input[name="accessLevel"][value="${accessValue}"]`)
+      .check();
 
-    // 4. Send the sharing request.
+    // 4. Send the sharing request. The button label flips between
+    // "Authorize Exchange" (bulk) and "Set Permissions" (personalized).
     await page
-      .getByRole("button", { name: /authorize exchange/i })
+      .locator("button", { hasText: /authorize exchange/i })
       .first()
       .click();
+    await page.waitForLoadState("domcontentloaded");
   }
 }

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -31,22 +31,28 @@ describe("Connection & Sharing (e2e)", () => {
   let failed = false;
 
   beforeAll(async () => {
-    provider = createClient(config, config.provider);
-    peer = createClient(config, config.peer);
+    try {
+      provider = createClient(config, config.provider);
+      peer = createClient(config, config.peer);
 
-    peerAccountId = await peer.pm.getAccountId();
-    fixture = await ensurePeerFixtures(peer);
+      peerAccountId = await peer.pm.getAccountId();
+      fixture = await ensurePeerFixtures(peer);
 
-    await ensureCleanProviderState(provider.pm, config.peer.username);
-    await disconnectIfConnected(provider.pm, peerAccountId);
+      await ensureCleanProviderState(provider.pm, config.peer.username);
+      await disconnectIfConnected(provider.pm, peerAccountId);
 
-    ui = new EspmWebUi({
-      baseUrl: config.webUiUrl,
-      headless: config.headless,
-      traceDir: config.traceDir,
-    });
-    await ui.launch();
-    await ui.login(config.peer.username, config.peer.password);
+      ui = new EspmWebUi({
+        baseUrl: config.webUiUrl,
+        headless: config.headless,
+        traceDir: config.traceDir,
+      });
+      await ui.launch();
+      await ui.login(config.peer.username, config.peer.password);
+    } catch (error) {
+      // Ensure afterAll writes the trace for setup failures too.
+      failed = true;
+      throw error;
+    }
   });
 
   afterAll(async () => {

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -177,10 +177,16 @@ describe("Connection & Sharing (e2e)", () => {
   });
 
   step("disconnect returns the accounts to baseline", async () => {
+    const connectedBefore = await provider.pm.getCustomerList();
+    expect(connectedBefore.map((c) => c.id)).toContain(peerAccountId);
+
     await provider.pm.disconnect(peerAccountId, {
       keepShares: false,
       note: "e2e disconnect",
     });
+
+    const connectedAfter = await provider.pm.getCustomerList();
+    expect(connectedAfter.map((c) => c.id)).not.toContain(peerAccountId);
 
     const pendingConnections = await provider.pm.getPendingConnections();
     expect(

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { PortfolioManagerApiError } from "../../src/PortfolioManagerApi.js";
 import { EspmWebUi } from "./EspmWebUi.js";
 import {
   createClient,
@@ -67,6 +68,22 @@ describe("Connection & Sharing (e2e)", () => {
       // Shared test environment: never mask a test failure with cleanup noise.
     }
   });
+
+  /**
+   * Asserts the call fails specifically because access is revoked (ESPM
+   * answers 403 Access Denied, occasionally 404), so transient failures
+   * (5xx, network) don't masquerade as successful revocation.
+   */
+  async function expectNoAccess(promise: Promise<unknown>): Promise<void> {
+    try {
+      await promise;
+    } catch (error) {
+      expect(error).toBeInstanceOf(PortfolioManagerApiError);
+      expect([403, 404]).toContain((error as PortfolioManagerApiError).status);
+      return;
+    }
+    throw new Error("Expected access to be revoked, but the call succeeded");
+  }
 
   function step(name: string, fn: () => Promise<void>): void {
     it(name, async () => {
@@ -153,9 +170,7 @@ describe("Connection & Sharing (e2e)", () => {
     await provider.pm.unshareMeter(fixture.meterId, "e2e unshare");
     await provider.pm.unshareProperty(fixture.propertyId, "e2e unshare");
 
-    await expect(
-      provider.pm.getProperty(fixture.propertyId)
-    ).rejects.toThrow();
+    await expectNoAccess(provider.pm.getProperty(fixture.propertyId));
 
     // Seed a second share and exercise the reject path.
     await ui.setupDataExchangeShare({
@@ -177,9 +192,7 @@ describe("Connection & Sharing (e2e)", () => {
       }
     }
 
-    await expect(
-      provider.pm.getProperty(fixture.propertyId)
-    ).rejects.toThrow();
+    await expectNoAccess(provider.pm.getProperty(fixture.propertyId));
   });
 
   step("disconnect returns the accounts to baseline", async () => {

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { EspmWebUi } from "./EspmWebUi.js";
+import {
+  createClient,
+  disconnectIfConnected,
+  ensureCleanProviderState,
+  ensurePeerFixtures,
+  getE2eConfig,
+  waitFor,
+  E2E_PROPERTY_NAME,
+  IE2eClient,
+} from "./support.js";
+
+/**
+ * End-to-end lifecycle for connections and sharing. The peer account
+ * (PM_USERNAME2) initiates requests through the pmtest web UI via Playwright;
+ * the provider account (PM_USERNAME) exercises the SDK against wstest.
+ *
+ * Steps intentionally share state and run sequentially — each depends on the
+ * one before it. See plans/connection-sharing-e2e-tests.md.
+ */
+
+const config = getE2eConfig();
+
+describe("Connection & Sharing (e2e)", () => {
+  let provider: IE2eClient;
+  let peer: IE2eClient;
+  let ui: EspmWebUi;
+  let peerAccountId: number;
+  let fixture: { propertyId: number; meterId: number };
+  let failed = false;
+
+  beforeAll(async () => {
+    provider = createClient(config, config.provider);
+    peer = createClient(config, config.peer);
+
+    peerAccountId = await peer.pm.getAccountId();
+    fixture = await ensurePeerFixtures(peer);
+
+    await ensureCleanProviderState(provider.pm, config.peer.username);
+    await disconnectIfConnected(provider.pm, peerAccountId);
+
+    ui = new EspmWebUi({
+      baseUrl: config.webUiUrl,
+      headless: config.headless,
+      traceDir: config.traceDir,
+    });
+    await ui.launch();
+    await ui.login(config.peer.username, config.peer.password);
+  });
+
+  afterAll(async () => {
+    // Keep the trace only for failed runs; passing runs stay tidy.
+    await ui?.close(failed ? `connection-sharing-${Date.now()}` : undefined);
+
+    // Best-effort return to baseline for the next run.
+    try {
+      await ensureCleanProviderState(provider.pm, config.peer.username);
+      await disconnectIfConnected(provider.pm, peerAccountId);
+    } catch {
+      // Shared test environment: never mask a test failure with cleanup noise.
+    }
+  });
+
+  function step(name: string, fn: () => Promise<void>): void {
+    it(name, async () => {
+      try {
+        await fn();
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
+    });
+  }
+
+  step("peer sends a connection request; provider sees and accepts it", async () => {
+    await ui.sendConnectionRequest(config.provider.username);
+
+    const pending = await waitFor(
+      async () => {
+        const connections = await provider.pm.getPendingConnections();
+        return connections.find((c) => c.username === config.peer.username);
+      },
+      { label: "pending connection from peer" }
+    );
+    expect(pending.accountId).toBe(peerAccountId);
+
+    await provider.pm.acceptConnection(pending.accountId, "e2e accept");
+
+    const stillPending = await provider.pm.getPendingConnections();
+    expect(
+      stillPending.find((c) => c.username === config.peer.username)
+    ).toBeUndefined();
+  });
+
+  step("peer shares the fixture property for data exchange", async () => {
+    await ui.setupDataExchangeShare({
+      providerUsername: config.provider.username,
+      propertyNames: [E2E_PROPERTY_NAME],
+      accessLevel: "Full Access",
+    });
+
+    const pendingProperty = await waitFor(
+      async () => {
+        const shares = await provider.pm.getPendingPropertyShares();
+        return shares.find((s) => s.sharerUsername === config.peer.username);
+      },
+      { label: "pending property share from peer" }
+    );
+    expect(pendingProperty.propertyId).toBe(fixture.propertyId);
+    expect(pendingProperty.propertyName).toBe(E2E_PROPERTY_NAME);
+
+    await provider.pm.acceptPropertyShare(pendingProperty.propertyId, "e2e accept");
+
+    // Accepted share grants real read access to the peer's property.
+    const property = await provider.pm.getProperty(fixture.propertyId);
+    expect(property.name).toBe(E2E_PROPERTY_NAME);
+  });
+
+  step(
+    "meter share must be accepted separately, then grants meter access",
+    async () => {
+      // Property-share acceptance must NOT have auto-accepted the meter share.
+      const pendingMeter = await waitFor(
+        async () => {
+          const shares = await provider.pm.getPendingMeterShares();
+          return shares.find((s) => s.sharerUsername === config.peer.username);
+        },
+        { label: "pending meter share from peer" }
+      );
+      expect(pendingMeter.id).toBe(fixture.meterId);
+      expect(pendingMeter.propertyId).toBe(fixture.propertyId);
+
+      await provider.pm.acceptMeterShare(pendingMeter.id, "e2e accept");
+
+      const meter = await provider.pm.getMeter(fixture.meterId);
+      expect(meter.id).toBe(fixture.meterId);
+    }
+  );
+
+  step("unshare removes access; a re-share can be rejected", async () => {
+    await provider.pm.unshareMeter(fixture.meterId, "e2e unshare");
+    await provider.pm.unshareProperty(fixture.propertyId, "e2e unshare");
+
+    await expect(
+      provider.pm.getProperty(fixture.propertyId)
+    ).rejects.toThrow();
+
+    // Seed a second share and exercise the reject path.
+    await ui.setupDataExchangeShare({
+      providerUsername: config.provider.username,
+      propertyNames: [E2E_PROPERTY_NAME],
+      accessLevel: "Read Only Access",
+    });
+    const pending = await waitFor(
+      async () => {
+        const shares = await provider.pm.getPendingPropertyShares();
+        return shares.find((s) => s.sharerUsername === config.peer.username);
+      },
+      { label: "second pending property share from peer" }
+    );
+    await provider.pm.rejectPropertyShare(pending.propertyId, "e2e reject");
+    for (const share of await provider.pm.getPendingMeterShares()) {
+      if (share.sharerUsername === config.peer.username) {
+        await provider.pm.rejectMeterShare(share.id, "e2e reject");
+      }
+    }
+
+    await expect(
+      provider.pm.getProperty(fixture.propertyId)
+    ).rejects.toThrow();
+  });
+
+  step("disconnect returns the accounts to baseline", async () => {
+    await provider.pm.disconnect(peerAccountId, {
+      keepShares: false,
+      note: "e2e disconnect",
+    });
+
+    const pendingConnections = await provider.pm.getPendingConnections();
+    expect(
+      pendingConnections.find((c) => c.username === config.peer.username)
+    ).toBeUndefined();
+  });
+});

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -68,6 +68,11 @@ describe("Connection & Sharing (e2e)", () => {
         await fn();
       } catch (error) {
         failed = true;
+        try {
+          console.error(`step '${name}' failed with UI at ${ui.page.url()}`);
+        } catch {
+          // Browser already closed; the original error is what matters.
+        }
         throw error;
       }
     });

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -1,9 +1,21 @@
 /**
- * Selector-maintenance probe for the pmtest web UI. Logs in as the peer
- * account and dumps link/form structure for the page named on the CLI, so
- * EspmWebUi locators can be validated without guessing.
+ * Selector-maintenance probe for the pmtest web UI. Logs in and dumps
+ * link/form structure for the flow step named on the CLI, so EspmWebUi
+ * locators can be validated without guessing.
  *
- *   npx tsx test/e2e/probe.ts home|contacts|add|sharing|wsshare
+ *   npx tsx test/e2e/probe.ts <target>
+ *
+ * Targets (peer account unless noted):
+ *   home              landing page after login
+ *   contacts          contact book
+ *   add               contact book -> Add Contact form
+ *   connect           search for the provider, stop on the request page
+ *   sendconnect       actually send a connection request to the provider
+ *   sharing           Sharing tab
+ *   wsshare           accept pending connection as provider (SDK), then dump
+ *                     the data-exchange share flow incl. property picker
+ *   provider-settings account settings as the PROVIDER account; add
+ *                     --make-searchable to enable username searchability
  */
 import { EspmWebUi } from "./EspmWebUi.js";
 
@@ -15,6 +27,12 @@ const username =
 const password =
   (asProvider ? process.env.PM_PASSWORD : process.env.PM_PASSWORD2) || "";
 if (!username || !password) throw new Error("Set PM_USERNAME(2)/PM_PASSWORD(2)");
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Set ${name} for the '${target}' target`);
+  return value;
+}
 
 const ui = new EspmWebUi({ headless: process.env.E2E_HEADLESS !== "false" });
 
@@ -87,7 +105,7 @@ try {
       await dump("add contact");
     }
   } else if (target === "connect") {
-    const providerUsername = process.env.PM_USERNAME || "";
+    const providerUsername = requireEnv("PM_USERNAME");
     await page.goto(`${ui.baseUrl}/contact/list`, {
       waitUntil: "domcontentloaded",
     });
@@ -109,7 +127,7 @@ try {
       .click();
     await dump("connection request page");
   } else if (target === "sendconnect") {
-    await ui.sendConnectionRequest(process.env.PM_USERNAME || "");
+    await ui.sendConnectionRequest(requireEnv("PM_USERNAME"));
     await dump("after send connection request");
   } else if (target === "provider-settings") {
     await page
@@ -160,8 +178,8 @@ try {
       const provider = new PortfolioManager(
         new PortfolioManagerApi(
           "https://portfoliomanager.energystar.gov/wstest/",
-          process.env.PM_USERNAME || "",
-          process.env.PM_PASSWORD || ""
+          requireEnv("PM_USERNAME"),
+          requireEnv("PM_PASSWORD")
         )
       );
       const pending = (await provider.getPendingConnections()).find(

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -171,7 +171,10 @@ try {
       .locator("option", { hasText: requireEnv("PM_USERNAME") })
       .first();
     await opt.waitFor({ state: "attached" });
-    await providerSelect.selectOption((await opt.getAttribute("value")) || "");
+    const optValue = await opt.getAttribute("value");
+    await providerSelect.selectOption(
+      optValue ? optValue : { label: (await opt.innerText()).trim() }
+    );
     await page.locator("#buttonSelectProperties").click();
     const dialog = page.locator("#modalDialogSelectProperties");
     await dialog.waitFor({ state: "visible" });

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -14,8 +14,14 @@
  *   sharing           Sharing tab
  *   wsshare           accept pending connection as provider (SDK), then dump
  *                     the data-exchange share flow incl. property picker
+ *   doshare           perform the full data-exchange share flow (requires a
+ *                     live connection) with viewmodel/network instrumentation;
+ *                     E2E_PROPERTY_NAME overrides the property to share
  *   provider-settings account settings as the PROVIDER account; add
  *                     --make-searchable to enable username searchability
+ *
+ * See also test/e2e/state.ts to dump the provider-side pending/connected
+ * state via the SDK.
  */
 import { EspmWebUi } from "./EspmWebUi.js";
 

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -34,7 +34,10 @@ function requireEnv(name: string): string {
   return value;
 }
 
-const ui = new EspmWebUi({ headless: process.env.E2E_HEADLESS !== "false" });
+const ui = new EspmWebUi({
+  baseUrl: process.env.PM_WEB_ENDPOINT,
+  headless: process.env.E2E_HEADLESS !== "false",
+});
 
 async function dump(label: string) {
   const page = ui.page;
@@ -175,9 +178,10 @@ try {
       const { PortfolioManagerApi } = await import(
         "../../src/PortfolioManagerApi.js"
       );
+      const { DEFAULT_API_URL } = await import("./support.js");
       const provider = new PortfolioManager(
         new PortfolioManagerApi(
-          "https://portfoliomanager.energystar.gov/wstest/",
+          process.env.PM_ENDPOINT || DEFAULT_API_URL,
           requireEnv("PM_USERNAME"),
           requireEnv("PM_PASSWORD")
         )

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -1,0 +1,205 @@
+/**
+ * Selector-maintenance probe for the pmtest web UI. Logs in as the peer
+ * account and dumps link/form structure for the page named on the CLI, so
+ * EspmWebUi locators can be validated without guessing.
+ *
+ *   npx tsx test/e2e/probe.ts home|contacts|add|sharing|wsshare
+ */
+import { EspmWebUi } from "./EspmWebUi.js";
+
+const target = process.argv[2] || "home";
+// Most targets act as the peer; account-settings targets act as the provider.
+const asProvider = target.startsWith("provider-");
+const username =
+  (asProvider ? process.env.PM_USERNAME : process.env.PM_USERNAME2) || "";
+const password =
+  (asProvider ? process.env.PM_PASSWORD : process.env.PM_PASSWORD2) || "";
+if (!username || !password) throw new Error("Set PM_USERNAME(2)/PM_PASSWORD(2)");
+
+const ui = new EspmWebUi({ headless: process.env.E2E_HEADLESS !== "false" });
+
+async function dump(label: string) {
+  const page = ui.page;
+  await page.waitForLoadState("networkidle", { timeout: 30000 }).catch(() => {});
+  console.log(`\n=== ${label} @ ${page.url()}`);
+  console.log(`title: ${await page.title()}`);
+  console.log(
+    "frames:",
+    JSON.stringify(page.frames().map((f) => f.url()))
+  );
+  const bodyText = await page
+    .locator("body")
+    .innerText()
+    .catch(() => "");
+  console.log("body text:", bodyText.replace(/\s+/g, " ").slice(0, 1500));
+  const links = await page
+    .locator("a")
+    .evaluateAll((els) =>
+      els
+        .map((e) => ({
+          text: (e.textContent || "").replace(/\s+/g, " ").trim().slice(0, 70),
+          href: (e.getAttribute("href") || "").slice(0, 90),
+        }))
+        .filter((l) => l.text)
+    );
+  console.log("links:", JSON.stringify(links.slice(0, 120), null, 1));
+  const inputs = await page
+    .locator("input, select, button")
+    .evaluateAll((els) =>
+      els.map((e) => ({
+        tag: e.tagName.toLowerCase(),
+        type: e.getAttribute("type"),
+        name: e.getAttribute("name"),
+        id: e.getAttribute("id"),
+        value: (e.getAttribute("value") || "").slice(0, 40),
+        text: (e.textContent || "").replace(/\s+/g, " ").trim().slice(0, 60),
+      }))
+    );
+  console.log("controls:", JSON.stringify(inputs.slice(0, 80), null, 1));
+}
+
+try {
+  await ui.launch();
+  await ui.login(username, password);
+  await dump("after login");
+
+  const page = ui.page;
+  if (target === "contacts" || target === "add") {
+    await page.getByRole("link", { name: /contacts/i }).first().click();
+    await page.waitForLoadState("domcontentloaded");
+    await dump("contacts");
+    if (target === "add") {
+      const addCandidates = await page.evaluate(() =>
+        Array.from(document.querySelectorAll("*"))
+          .filter((e) => {
+            const direct = Array.from(e.childNodes)
+              .filter((n) => n.nodeType === 3)
+              .map((n) => n.textContent || "")
+              .join(" ");
+            const value = (e as HTMLInputElement).value || "";
+            return /add new contacts/i.test(direct + " " + value);
+          })
+          .map((e) => e.outerHTML.slice(0, 400))
+      );
+      console.log("add candidates:", JSON.stringify(addCandidates, null, 1));
+      await page.getByText(/add new contacts/i).first().click();
+      await page.waitForLoadState("domcontentloaded");
+      await dump("add contact");
+    }
+  } else if (target === "connect") {
+    const providerUsername = process.env.PM_USERNAME || "";
+    await page.goto(`${ui.baseUrl}/contact/list`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page
+      .getByRole("button", { name: /add new contacts/i })
+      .first()
+      .click();
+    await page.locator("#searchContactUsername").fill(providerUsername);
+    console.log(
+      "username field value after fill:",
+      await page.locator("#searchContactUsername").inputValue()
+    );
+    await page.getByRole("button", { name: /^search$/i }).first().click();
+    await dump("search results");
+    await page
+      .getByRole("button", { name: /^connect$/i })
+      .or(page.getByRole("link", { name: /^connect$/i }))
+      .first()
+      .click();
+    await dump("connection request page");
+  } else if (target === "sendconnect") {
+    await ui.sendConnectionRequest(process.env.PM_USERNAME || "");
+    await dump("after send connection request");
+  } else if (target === "provider-settings") {
+    await page
+      .getByRole("link", { name: /account settings/i })
+      .first()
+      .click();
+    await page.waitForLoadState("domcontentloaded");
+    await dump("account settings");
+    const radios = await page.evaluate(() =>
+      Array.from(
+        document.querySelectorAll("#contact-is-searchable-div input")
+      ).map((e) => e.outerHTML)
+    );
+    console.log("searchable radios:", JSON.stringify(radios, null, 1));
+    const submits = await page.evaluate(() =>
+      Array.from(
+        document.querySelectorAll(
+          'button[type="submit"], input[type="submit"], button'
+        )
+      )
+        .map((e) => e.outerHTML.slice(0, 200))
+        .slice(0, 20)
+    );
+    console.log("submit candidates:", JSON.stringify(submits, null, 1));
+    if (process.argv[3] === "--make-searchable") {
+      const preferencesTab = page.getByRole("link", { name: /preferences/i });
+      if (await preferencesTab.count()) {
+        await preferencesTab.first().click();
+      }
+      const yes = page.locator("#contact-is-searchable-radio-yes");
+      if (!(await yes.isChecked())) {
+        await yes.check({ force: true });
+        console.log("checked yes:", await yes.isChecked());
+        await page.locator("#submitButtonMargin").click();
+        await dump("after save");
+      } else {
+        console.log("already searchable");
+      }
+    }
+  } else if (target === "sharing" || target === "wsshare") {
+    if (target === "wsshare") {
+      // A share needs a live connection: peer sends the request via the UI,
+      // provider accepts via the SDK.
+      const { PortfolioManager } = await import("../../src/PortfolioManager.js");
+      const { PortfolioManagerApi } = await import(
+        "../../src/PortfolioManagerApi.js"
+      );
+      const provider = new PortfolioManager(
+        new PortfolioManagerApi(
+          "https://portfoliomanager.energystar.gov/wstest/",
+          process.env.PM_USERNAME || "",
+          process.env.PM_PASSWORD || ""
+        )
+      );
+      const pending = (await provider.getPendingConnections()).find(
+        (c) => c.username === username
+      );
+      if (pending) {
+        await provider.acceptConnection(pending.accountId, "probe accept");
+        console.log("accepted pending connection from", username);
+      } else {
+        console.log("no pending connection; assuming already connected");
+      }
+    }
+    await page.goto(`${ui.baseUrl}/sharing`, { waitUntil: "domcontentloaded" });
+    await dump("sharing");
+    if (target === "wsshare") {
+      await page
+        .getByRole("link", {
+          name: /set up web services|share .*data exchange|exchanging data/i,
+        })
+        .first()
+        .click();
+      await page.waitForLoadState("domcontentloaded");
+      await dump("ws bulk sharing");
+      await page.locator("#buttonSelectProperties").click();
+      await page.waitForTimeout(3000);
+      const dialogHtml = await page.evaluate(() =>
+        Array.from(
+          document.querySelectorAll(
+            '[id*="dialog" i], [class*="modal" i], [class*="dialog" i]'
+          )
+        )
+          .filter((e) => (e as HTMLElement).offsetParent !== null)
+          .map((e) => e.outerHTML.slice(0, 3000))
+          .slice(0, 3)
+      );
+      console.log("dialogs:", JSON.stringify(dialogHtml, null, 1));
+    }
+  }
+} finally {
+  await ui.close();
+}

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -52,7 +52,7 @@ async function dump(label: string) {
     .locator("body")
     .innerText()
     .catch(() => "");
-  console.log("body text:", bodyText.replace(/\s+/g, " ").slice(0, 1500));
+  console.log("body text:", bodyText.replace(/\s+/g, " ").slice(0, 6000));
   const links = await page
     .locator("a")
     .evaluateAll((els) =>
@@ -129,6 +129,157 @@ try {
       .first()
       .click();
     await dump("connection request page");
+  } else if (target === "doshare") {
+    // Reproduce the full share flow with dumps after each phase. Assumes a
+    // live connection (run sendconnect + wsshare first, or the e2e step 1).
+    page.on("response", (r) => {
+      if (r.url().includes("portfoliomanager") && r.status() >= 400) {
+        console.log(`HTTP ${r.status()} ${r.request().method()} ${r.url()}`);
+      }
+    });
+    page.on("request", (r) => {
+      if (r.url().includes("wsBulkSharing")) {
+        console.log(`REQ ${r.method()} ${r.url()}`);
+      }
+    });
+    page.on("requestfailed", (r) => {
+      console.log(
+        `REQFAILED ${r.method()} ${r.url().slice(0, 140)} => ${r.failure()?.errorText}`
+      );
+    });
+    page.on("requestfinished", (r) => {
+      if (r.url().includes("authorizeExchange")) {
+        console.log(`REQFINISHED ${r.method()} ${r.url()}`);
+      }
+    });
+    await page.goto(`${ui.baseUrl}/sharing`, { waitUntil: "domcontentloaded" });
+    await page
+      .getByRole("link", {
+        name: /set up web services|share .*data exchange|exchanging data/i,
+      })
+      .first()
+      .click();
+    await page.waitForLoadState("domcontentloaded");
+    const providerSelect = page.locator("select").first();
+    const opt = providerSelect
+      .locator("option", { hasText: requireEnv("PM_USERNAME") })
+      .first();
+    await opt.waitFor({ state: "attached" });
+    await providerSelect.selectOption((await opt.getAttribute("value")) || "");
+    await page.locator("#buttonSelectProperties").click();
+    const dialog = page.locator("#modalDialogSelectProperties");
+    await dialog.waitFor({ state: "visible" });
+    await dialog
+      .locator("#modalDialogSelectPropertiesTable tbody tr", {
+        hasText: process.env.E2E_PROPERTY_NAME || "E2E Share Fixture Property",
+      })
+      .locator('input[type="checkbox"]')
+      .first()
+      .check();
+    await dialog.getByText(/apply selection/i).first().click();
+    await dialog.waitFor({ state: "hidden" });
+    await page.locator('input[name="bulk"][value="yes"]').click();
+    await page.locator('input[name="accessLevel"][value="FULL_ACCESS"]').click();
+    const radioState = () =>
+      page.evaluate(() => ({
+        bulk: (
+          document.querySelector('input[name="bulk"]:checked') as
+            | HTMLInputElement
+            | null
+        )?.value,
+        accessLevel: (
+          document.querySelector('input[name="accessLevel"]:checked') as
+            | HTMLInputElement
+            | null
+        )?.value,
+        accessLevelBindings: Array.from(
+          document.querySelectorAll('input[name="accessLevel"]')
+        ).map((e) => e.getAttribute("data-bind")),
+        errors: Array.from(
+          document.querySelectorAll(
+            '[class*="error" i], [class*="alert" i], [class*="notice" i]'
+          )
+        )
+          .filter((e) => (e as HTMLElement).offsetParent !== null)
+          .map((e) => (e.textContent || "").replace(/\s+/g, " ").trim().slice(0, 200)),
+        koLoading: (() => {
+          const w = window as unknown as {
+            ko?: { dataFor: (e: Element | null) => { loading?: () => boolean } };
+          };
+          try {
+            return w.ko
+              ?.dataFor(document.querySelector("#choose-permissions-form"))
+              ?.loading?.();
+          } catch {
+            return "ko-error";
+          }
+        })(),
+      }));
+    console.log("radio state before:", JSON.stringify(await radioState()));
+    const handlerSource = await page.evaluate(async () => {
+      const out: string[] = [];
+      const srcs = Array.from(document.scripts)
+        .map((s) => s.src)
+        .filter(Boolean);
+      for (const src of srcs) {
+        try {
+          const text = await fetch(src).then((r) => r.text());
+          let i = text.indexOf("authorizeExchange");
+          while (i >= 0 && out.length < 4) {
+            out.push(
+              `--- ${src}\n` + text.slice(Math.max(0, i - 300), i + 2200)
+            );
+            i = text.indexOf("authorizeExchange", i + 1);
+          }
+        } catch {
+          // cross-origin or fetch failure — skip
+        }
+      }
+      return out.join("\n\n");
+    });
+    console.log("authorizeExchange source:\n", handlerSource.slice(0, 9000));
+    page.on("console", (m) => {
+      if (m.type() === "error" || m.type() === "warning") {
+        console.log(`CONSOLE ${m.type()}: ${m.text().slice(0, 300)}`);
+      }
+    });
+    page.on("pageerror", (e) => console.log(`PAGEERROR: ${String(e).slice(0, 300)}`));
+    await dump("before authorize");
+    const authorizeButtons = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("button, input, a"))
+        .filter((e) =>
+          /authorize exchange/i.test(
+            (e.textContent || "") + " " + ((e as HTMLInputElement).value || "")
+          )
+        )
+        .map((e) => ({
+          html: e.outerHTML.slice(0, 400),
+          visible: (e as HTMLElement).offsetParent !== null,
+        }))
+    );
+    console.log("authorize buttons:", JSON.stringify(authorizeButtons, null, 1));
+    page.on("dialog", (d) => {
+      console.log(`DIALOG type=${d.type()} message=${d.message()}`);
+      void d.accept();
+    });
+    page.on("response", (r) => {
+      if (r.request().method() === "POST") {
+        console.log(`POST ${r.status()} ${r.url()}`);
+      }
+    });
+    const responsePromise = page
+      .waitForResponse((r) => r.url().includes("authorizeExchange.json"), {
+        timeout: 240000,
+      })
+      .then((r) => console.log(`AUTHORIZE RESPONSE ${r.status()} after wait`))
+      .catch(() => console.log("AUTHORIZE RESPONSE never arrived in 240s"));
+    await page
+      .locator("button", { hasText: /authorize exchange/i })
+      .first()
+      .click();
+    await responsePromise;
+    console.log("radio state after:", JSON.stringify(await radioState()));
+    await dump("after authorize");
   } else if (target === "sendconnect") {
     await ui.sendConnectionRequest(requireEnv("PM_USERNAME"));
     await dump("after send connection request");

--- a/test/e2e/probe.ts
+++ b/test/e2e/probe.ts
@@ -264,9 +264,10 @@ try {
         }))
     );
     console.log("authorize buttons:", JSON.stringify(authorizeButtons, null, 1));
+    // Log only — EspmWebUi.launch() already registers an accepting handler,
+    // and a second accept() would reject with "dialog is already handled".
     page.on("dialog", (d) => {
       console.log(`DIALOG type=${d.type()} message=${d.message()}`);
-      void d.accept();
     });
     page.on("response", (r) => {
       if (r.request().method() === "POST") {

--- a/test/e2e/state.ts
+++ b/test/e2e/state.ts
@@ -2,11 +2,15 @@
 import { PortfolioManager } from "../../src/PortfolioManager.js";
 import { PortfolioManagerApi } from "../../src/PortfolioManagerApi.js";
 
+if (!process.env.PM_USERNAME || !process.env.PM_PASSWORD) {
+  throw new Error("Set PM_USERNAME and PM_PASSWORD (provider account)");
+}
+
 const pm = new PortfolioManager(
   new PortfolioManagerApi(
     process.env.PM_ENDPOINT || "https://portfoliomanager.energystar.gov/wstest/",
-    process.env.PM_USERNAME || "",
-    process.env.PM_PASSWORD || ""
+    process.env.PM_USERNAME,
+    process.env.PM_PASSWORD
   )
 );
 

--- a/test/e2e/state.ts
+++ b/test/e2e/state.ts
@@ -1,0 +1,25 @@
+/** Dumps provider-side pending/connected state. Debug utility. */
+import { PortfolioManager } from "../../src/PortfolioManager.js";
+import { PortfolioManagerApi } from "../../src/PortfolioManagerApi.js";
+
+const pm = new PortfolioManager(
+  new PortfolioManagerApi(
+    process.env.PM_ENDPOINT || "https://portfoliomanager.energystar.gov/wstest/",
+    process.env.PM_USERNAME || "",
+    process.env.PM_PASSWORD || ""
+  )
+);
+
+console.log(
+  "pending property shares:",
+  JSON.stringify(await pm.getPendingPropertyShares())
+);
+console.log(
+  "pending meter shares:",
+  JSON.stringify(await pm.getPendingMeterShares())
+);
+console.log(
+  "pending connections:",
+  JSON.stringify(await pm.getPendingConnections())
+);
+console.log("customers:", JSON.stringify(await pm.getCustomerList()));

--- a/test/e2e/support.ts
+++ b/test/e2e/support.ts
@@ -108,10 +108,11 @@ export async function ensurePeerFixtures(
 }
 
 /**
- * Returns the provider account to a known baseline with respect to the peer:
- * rejects any pending connection/share requests from the peer and drops an
- * existing connection (removing shares). Scoped to the peer account so other
- * pending requests in the shared test environment are left alone.
+ * Rejects any pending connection/share requests from the peer, scoped to the
+ * peer account so other pending requests in the shared test environment are
+ * left alone. An already-accepted connection is dropped separately via
+ * disconnectIfConnected (it needs the peer's account id, which pending lists
+ * don't provide once accepted).
  */
 export async function ensureCleanProviderState(
   provider: PortfolioManager,

--- a/test/e2e/support.ts
+++ b/test/e2e/support.ts
@@ -1,5 +1,8 @@
 import { PortfolioManager } from "../../src/PortfolioManager.js";
-import { PortfolioManagerApi } from "../../src/PortfolioManagerApi.js";
+import {
+  PortfolioManagerApi,
+  PortfolioManagerApiError,
+} from "../../src/PortfolioManagerApi.js";
 import { ensureStandardMeterFixture } from "../../src/test/ensureStandardMeterFixture.js";
 import { ensureStandardProperties } from "../../src/test/ensureStandardProperties.js";
 import { DEFAULT_WEB_UI_URL } from "./EspmWebUi.js";
@@ -139,8 +142,9 @@ export async function ensureCleanProviderState(
 }
 
 /**
- * Best-effort disconnect from the peer account, removing any accepted shares.
- * Errors (e.g. "not connected") are swallowed: baseline is the goal.
+ * Disconnects from the peer account, removing any accepted shares. The
+ * not-connected case (ESPM answers 403 "Access Denied", or 404) is treated as
+ * already-at-baseline; anything else (auth, network, 5xx) is a real failure.
  */
 export async function disconnectIfConnected(
   provider: PortfolioManager,
@@ -151,7 +155,13 @@ export async function disconnectIfConnected(
       keepShares: false,
       note: "e2e cleanup",
     });
-  } catch {
-    // Not connected — already at baseline.
+  } catch (error) {
+    if (
+      error instanceof PortfolioManagerApiError &&
+      (error.status === 403 || error.status === 404)
+    ) {
+      return; // Not connected — already at baseline.
+    }
+    throw error;
   }
 }

--- a/test/e2e/support.ts
+++ b/test/e2e/support.ts
@@ -1,0 +1,156 @@
+import { PortfolioManager } from "../../src/PortfolioManager.js";
+import { PortfolioManagerApi } from "../../src/PortfolioManagerApi.js";
+import { ensureStandardMeterFixture } from "../../src/test/ensureStandardMeterFixture.js";
+import { ensureStandardProperties } from "../../src/test/ensureStandardProperties.js";
+import { DEFAULT_WEB_UI_URL } from "./EspmWebUi.js";
+
+export const DEFAULT_API_URL = "https://portfoliomanager.energystar.gov/wstest/";
+
+export const E2E_PROPERTY_NAME = "E2E Share Fixture Property";
+export const E2E_METER_NAME = "E2E Share Fixture Meter";
+
+export interface IE2eConfig {
+  apiUrl: string;
+  webUiUrl: string;
+  /** Web services provider account under test (accepts via the API). */
+  provider: { username: string; password: string };
+  /** Persistent peer account that initiates connections/shares via the UI. */
+  peer: { username: string; password: string };
+  headless: boolean;
+  traceDir: string;
+}
+
+export function getE2eConfig(): IE2eConfig {
+  const provider = {
+    username: process.env.PM_USERNAME || "",
+    password: process.env.PM_PASSWORD || "",
+  };
+  const peer = {
+    username: process.env.PM_USERNAME2 || "",
+    password: process.env.PM_PASSWORD2 || "",
+  };
+  if (!provider.username || !provider.password || !peer.username || !peer.password) {
+    throw new Error(
+      "The e2e suite needs PM_USERNAME/PM_PASSWORD (provider) and " +
+        "PM_USERNAME2/PM_PASSWORD2 (persistent peer) environment variables."
+    );
+  }
+  return {
+    apiUrl: process.env.PM_ENDPOINT || DEFAULT_API_URL,
+    webUiUrl: process.env.PM_WEB_ENDPOINT || DEFAULT_WEB_UI_URL,
+    provider,
+    peer,
+    headless: process.env.E2E_HEADLESS !== "false",
+    traceDir: process.env.E2E_TRACE_DIR || "test-results/e2e",
+  };
+}
+
+export interface IE2eClient {
+  api: PortfolioManagerApi;
+  pm: PortfolioManager;
+}
+
+export function createClient(
+  config: IE2eConfig,
+  credentials: { username: string; password: string }
+): IE2eClient {
+  const api = new PortfolioManagerApi(
+    config.apiUrl,
+    credentials.username,
+    credentials.password
+  );
+  return { api, pm: new PortfolioManager(api) };
+}
+
+/**
+ * Polls until `probe` returns a defined value. UI-seeded requests can take a
+ * moment to appear in the web services pending lists.
+ */
+export async function waitFor<T>(
+  probe: () => Promise<T | undefined>,
+  options: { timeoutMs?: number; intervalMs?: number; label?: string } = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 60000;
+  const intervalMs = options.intervalMs ?? 5000;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const result = await probe();
+    if (result !== undefined) return result;
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for ${options.label || "condition"}`
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}
+
+/**
+ * Ensures the peer account owns the fixture property with one meter, and
+ * returns their ids. Runs against the web services API with peer credentials.
+ */
+export async function ensurePeerFixtures(
+  peer: IE2eClient
+): Promise<{ propertyId: number; meterId: number }> {
+  const accountId = await peer.pm.getAccountId();
+  const [propertyId] = await ensureStandardProperties(peer.api, accountId, [
+    E2E_PROPERTY_NAME,
+  ]);
+  const meter = await ensureStandardMeterFixture(
+    peer.api,
+    propertyId,
+    E2E_METER_NAME
+  );
+  if (meter.id === undefined) {
+    throw new Error("Expected fixture meter to have an id");
+  }
+  return { propertyId, meterId: meter.id };
+}
+
+/**
+ * Returns the provider account to a known baseline with respect to the peer:
+ * rejects any pending connection/share requests from the peer and drops an
+ * existing connection (removing shares). Scoped to the peer account so other
+ * pending requests in the shared test environment are left alone.
+ */
+export async function ensureCleanProviderState(
+  provider: PortfolioManager,
+  peerUsername: string
+): Promise<void> {
+  const note = "e2e ensureCleanProviderState";
+
+  for (const share of await provider.getPendingPropertyShares()) {
+    if (share.sharerUsername === peerUsername) {
+      await provider.rejectPropertyShare(share.propertyId, note);
+    }
+  }
+  for (const share of await provider.getPendingMeterShares()) {
+    if (share.sharerUsername === peerUsername) {
+      await provider.rejectMeterShare(share.id, note);
+    }
+  }
+
+  for (const connection of await provider.getPendingConnections()) {
+    if (connection.username === peerUsername) {
+      await provider.rejectConnection(connection.accountId, note);
+    }
+  }
+}
+
+/**
+ * Best-effort disconnect from the peer account, removing any accepted shares.
+ * Errors (e.g. "not connected") are swallowed: baseline is the goal.
+ */
+export async function disconnectIfConnected(
+  provider: PortfolioManager,
+  peerAccountId: number
+): Promise<void> {
+  try {
+    await provider.disconnect(peerAccountId, {
+      keepShares: false,
+      note: "e2e cleanup",
+    });
+  } catch {
+    // Not connected — already at baseline.
+  }
+}

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,10 +1,15 @@
 {
   // Typechecks the e2e suite (test/e2e is outside the build tsconfig's rootDir).
+  // Browser-automation code needs DOM types (page.evaluate callbacks) and
+  // top-level await (probe.ts), hence the lib/module/target overrides.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "baseUrl": "."
+    "baseUrl": ".",
+    "lib": ["esnext", "dom", "dom.iterable"],
+    "module": "es2022",
+    "target": "es2022"
   },
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts"],
   "include": ["src", "test/e2e"]

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,0 +1,11 @@
+{
+  // Typechecks the e2e suite (test/e2e is outside the build tsconfig's rootDir).
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "baseUrl": "."
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.spec.ts"],
+  "include": ["src", "test/e2e"]
+}

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,9 +10,10 @@ export default defineConfig({
     testTimeout: 300000,
     hookTimeout: 300000,
     fileParallelism: false,
-    // Lifecycle steps share state (connect -> share -> accept -> teardown),
-    // so a failed step must fail the rest instead of running against a
-    // half-torn-down environment.
+    // Lifecycle steps share state (connect -> share -> accept -> teardown):
+    // run them serially and stop at the first failure so later steps don't
+    // execute (and fail noisily) against a half-torn-down environment.
     sequence: { concurrent: false },
+    bail: 1,
   },
 });

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+// End-to-end connection/sharing suite. Kept out of the default `vitest run`
+// because it drives the ESPM test web UI with Playwright and mutates shared,
+// stateful test accounts — see plans/connection-sharing-e2e-tests.md.
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["test/e2e/**/*.e2e.spec.ts"],
+    testTimeout: 300000,
+    hookTimeout: 300000,
+    fileParallelism: false,
+    // Lifecycle steps share state (connect -> share -> accept -> teardown),
+    // so a failed step must fail the rest instead of running against a
+    // half-torn-down environment.
+    sequence: { concurrent: false },
+  },
+});


### PR DESCRIPTION
Implements and **live-validates** the connection/sharing e2e strategy planned in `plans/connection-sharing-e2e-tests.md` (included). Rebased onto `next` (the connection/sharing SDK merged via #22).

**Why:** ESPM's web services API is receive-only for connections and shares — a standard user must initiate them in the web UI. The suite drives the persistent peer account (`PM_USERNAME2`/`PM_PASSWORD2`) through the `pmtest` web UI with Playwright to seed requests, then exercises the SDK as the provider account (`PM_USERNAME`) against `wstest` to accept, verify real access, and clean up.

**Status: all 5 lifecycle steps pass against the live test environment (~26s):**
1. connection request (UI) → pending list → accept (SDK)
2. property share for data exchange (UI) → accept → real `getProperty` read
3. meter share must be accepted separately → real `getMeter` read
4. unshare removes access → re-share (UI) → reject path
5. disconnect returns to baseline

**What's here**
- `test/e2e/EspmWebUi.ts` — page-object seeder; all locators validated against the live UI and confined to this file
- `test/e2e/probe.ts` — selector-maintenance tool that dumps page structure per flow step (used to validate every locator; rerun when the ESPM UI drifts)
- `test/e2e/support.ts`, `connectionSharing.e2e.spec.ts` — config, polling, fixtures, lifecycle spec
- `vitest.e2e.config.ts`, `tsconfig.e2e.json`, `test:e2e`/`typecheck:e2e` — excluded from default `npm test`
- `.github/workflows/e2e.yml` — nightly + manual dispatch, serialized via `espm-test-env` concurrency group, traces on failure
- `wipeTestEnvironment` also rejects pending connections/shares now

**Live-validation findings** (details in the plan doc): pmtest stalls on the `load` event (suite waits for `domcontentloaded`); contacts live at `/contact/list`; the share flow is an Angular app; and the provider account had to be made *searchable* — done via `npx tsx test/e2e/probe.ts provider-settings --make-searchable` (persistent setting, re-apply after EPA environment refreshes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)