### PR TITLE
ci: serialize test matrix and dedupe runs to avoid ESPM rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,22 @@ on:
   push:
   workflow_dispatch:
 
+# One CI run at a time per branch: back-to-back pushes cancel the stale run
+# instead of doubling load on the ESPM test API. On main/next, queue instead
+# of cancel so an in-flight release is never killed mid-publish.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/next' }}
+
 jobs:
   test:
     name: test (node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # The ESPM test API rate-limits per account; running all node versions
+      # against it concurrently trips the limit, so run them one at a time.
+      max-parallel: 1
       matrix:
         node-version: ["20", "22", "lts/*", "latest"]
     env:


### PR DESCRIPTION
## Problem

CI runs like [28718709747](https://github.com/dopry/portfolio-manager/actions/runs/28718709747) fail with `429 Too Many Requests` (`errorNumber="-200" errorDescription="Rate limit exceeded."`) from the ESPM test API. The four node-version matrix jobs run the full live integration suite concurrently against the same test account, so the first job in wins and the rest get throttled (node 20 passed, the other three failed).

## Changes

- **`max-parallel: 1`** on the test matrix — the node 20/22/lts/latest legs now run sequentially instead of hammering the ESPM test API in parallel. Vitest already has `fileParallelism: false`, so within a job load was fine; cross-job concurrency was the problem.
- **Workflow-level `concurrency`** keyed on `ci-${{ github.ref }}` — rapid back-to-back pushes to a branch cancel the stale run instead of stacking more API load. On `main`/`next`, `cancel-in-progress` is disabled so an in-flight release job is never killed mid-publish; queued runs wait instead.

## Not in this PR (follow-ups from the same investigation)

- 429 retry with backoff in `PortfolioManagerApi`
- Running the live suite on a single matrix leg
- Dropping the duplicate `test:coverage` run in the release job

🤖 Generated with [Claude Code](https://claude.com/claude-code)