### PR TITLE
fix: retry requests rejected by the ESPM rate limiter

### DIFF
--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1063,11 +1063,12 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
       "test-pass",
       { maxRetries: 2, retryBaseDelayMs: 1 }
     );
-    const fetchMock = vi.mocked(fetch).mockResolvedValue(
-      new Response("<response status='Error' />", {
-        status: 429,
-        statusText: "Too Many Requests",
-      })
+    const fetchMock = vi.mocked(fetch).mockImplementation(
+      async () =>
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+        })
     );
 
     await expect(retryApi.fetch("property/7")).rejects.toMatchObject({

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1,5 +1,6 @@
 import { XMLParser } from "fast-xml-parser";
 import fetch, { Response } from "node-fetch";
+import { Readable } from "node:stream";
 import {
   afterAll,
   afterEach,
@@ -1002,6 +1003,32 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     });
     // initial request + maxRetries retries
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("fetch does not retry 429 responses when the body is not replayable", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi.mocked(fetch).mockResolvedValue(
+      new Response("<response status='Error' />", {
+        status: 429,
+        statusText: "Too Many Requests",
+      })
+    );
+
+    await expect(
+      retryApi.fetch("property/8", {
+        method: "POST",
+        body: Readable.from(["<property />"]),
+      })
+    ).rejects.toMatchObject({
+      status: 429,
+      statusText: "Too Many Requests",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("fetch omits auth header for POST account and includes it otherwise", async () => {

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -983,6 +983,75 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     }
   });
 
+  it("fetch honors Retry-After: 0 as an immediate retry", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "0" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("<response><status>Ok</status></response>", {
+          status: 200,
+          statusText: "OK",
+        })
+      );
+
+    const result = await retryApi.fetch<{ response: { status: string } }>(
+      "property/9"
+    );
+
+    expect(result.response.status).to.equal("Ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetch falls back to exponential backoff for non-numeric or negative Retry-After", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "Wed, 21 Oct 2026 07:28:00 GMT" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "-1" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("<response><status>Ok</status></response>", {
+          status: 200,
+          statusText: "OK",
+        })
+      );
+
+    const result = await retryApi.fetch<{ response: { status: string } }>(
+      "property/10"
+    );
+
+    expect(result.response.status).to.equal("Ok");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("fetch gives up after maxRetries consecutive 429 responses", async () => {
     const retryApi = new PortfolioManagerApi(
       "https://example.test/",

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -915,6 +915,95 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     });
   });
 
+  it("fetch retries 429 responses and succeeds once the rate limit clears", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("<response><status>Ok</status></response>", {
+          status: 200,
+          statusText: "OK",
+        })
+      );
+
+    const result = await retryApi.fetch<{ response: { status: string } }>(
+      "property/5"
+    );
+
+    expect(result.response.status).to.equal("Ok");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("fetch waits for a numeric Retry-After header before retrying", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi
+      .mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response("<response status='Error' />", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "1" },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response("<response><status>Ok</status></response>", {
+          status: 200,
+          statusText: "OK",
+        })
+      );
+
+    vi.useFakeTimers();
+    try {
+      const pending = retryApi.fetch<{ response: { status: string } }>(
+        "property/6"
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+      const result = await pending;
+      expect(result.response.status).to.equal("Ok");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fetch gives up after maxRetries consecutive 429 responses", async () => {
+    const retryApi = new PortfolioManagerApi(
+      "https://example.test/",
+      "test-user",
+      "test-pass",
+      { maxRetries: 2, retryBaseDelayMs: 1 }
+    );
+    const fetchMock = vi.mocked(fetch).mockResolvedValue(
+      new Response("<response status='Error' />", {
+        status: 429,
+        statusText: "Too Many Requests",
+      })
+    );
+
+    await expect(retryApi.fetch("property/7")).rejects.toMatchObject({
+      status: 429,
+      statusText: "Too Many Requests",
+    });
+    // initial request + maxRetries retries
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it("fetch omits auth header for POST account and includes it otherwise", async () => {
     const fetchMock = vi.mocked(fetch).mockImplementation(async () => {
       return new Response("<response><status>Ok</status></response>", {

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -974,7 +974,11 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
       const pending = retryApi.fetch<{ response: { status: string } }>(
         "property/6"
       );
-      await vi.advanceTimersByTimeAsync(1000);
+      // The header delay (1s) supersedes the 1ms backoff: just before it
+      // elapses the retry must not have fired yet.
+      await vi.advanceTimersByTimeAsync(999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(1);
       const result = await pending;
       expect(result.response.status).to.equal("Ok");
       expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -167,9 +167,14 @@ export class PortfolioManagerApi {
    * header, when present and numeric, takes precedence over exponential backoff.
    */
   private retryDelayMs(response: Response, attempt: number): number {
-    const retryAfter = Number(response.headers.get("retry-after"));
-    if (Number.isFinite(retryAfter) && retryAfter > 0) {
-      return retryAfter * 1000;
+    // Retry-After is delta-seconds, where 0 (retry immediately) is valid.
+    // Non-numeric forms (e.g. an HTTP-date) fall back to exponential backoff.
+    const header = response.headers.get("retry-after");
+    if (header !== null) {
+      const retryAfter = Number(header);
+      if (Number.isFinite(retryAfter) && retryAfter >= 0) {
+        return retryAfter * 1000;
+      }
     }
     return this.retryBaseDelayMs * 2 ** attempt;
   }

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -189,10 +189,12 @@ export class PortfolioManagerApi {
     let response = await fetch(url, init);
 
     // Retrying is safe even for POST/PUT: a rate-limited request is rejected
-    // before it is processed. Request bodies are strings, so they can be resent.
+    // before it is processed. Only requests with replayable (string or empty)
+    // bodies are retried; a consumed stream body cannot be resent.
+    const isReplayable = init.body == null || typeof init.body === "string";
     for (
       let attempt = 0;
-      response.status === 429 && attempt < this.maxRetries;
+      isReplayable && response.status === 429 && attempt < this.maxRetries;
       attempt++
     ) {
       const delay = this.retryDelayMs(response, attempt);

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -204,6 +204,9 @@ export class PortfolioManagerApi {
       attempt++
     ) {
       const delay = this.retryDelayMs(response, attempt);
+      // Drain the throttled response before discarding it so node-fetch can
+      // release the underlying socket.
+      await response.text();
       await new Promise((resolve) => setTimeout(resolve, delay));
       response = await fetch(url, init);
     }

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -85,7 +85,8 @@ export interface PortfolioManagerApiOptions {
   maxRetries?: number;
   /**
    * Base delay in milliseconds between retries, doubled on each attempt.
-   * Ignored when the response carries a Retry-After header.
+   * Ignored when the response carries a numeric (delta-seconds) Retry-After
+   * header; HTTP-date or negative values fall back to this backoff.
    */
   retryBaseDelayMs?: number;
 }

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -80,6 +80,16 @@ export function isPortfolioManagerApiError(
   return obj instanceof PortfolioManagerApiError;
 }
 
+export interface PortfolioManagerApiOptions {
+  /** Number of times to retry a request after a 429 Too Many Requests response. */
+  maxRetries?: number;
+  /**
+   * Base delay in milliseconds between retries, doubled on each attempt.
+   * Ignored when the response carries a Retry-After header.
+   */
+  retryBaseDelayMs?: number;
+}
+
 /**
  * Gateway to the the Portfolio Manager API.
  * see: https://portfoliomanager.energystar.gov/webservices/home/api
@@ -139,11 +149,30 @@ export class PortfolioManagerApi {
     },
   };
 
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
+
   constructor(
     private readonly endpoint: string,
     private readonly username: string,
-    private readonly password: string
-  ) {}
+    private readonly password: string,
+    options: PortfolioManagerApiOptions = {}
+  ) {
+    this.maxRetries = options.maxRetries ?? 3;
+    this.retryBaseDelayMs = options.retryBaseDelayMs ?? 1000;
+  }
+
+  /**
+   * The ESPM API rate-limits requests (429, errorNumber -200). A Retry-After
+   * header, when present and numeric, takes precedence over exponential backoff.
+   */
+  private retryDelayMs(response: Response, attempt: number): number {
+    const retryAfter = Number(response.headers.get("retry-after"));
+    if (Number.isFinite(retryAfter) && retryAfter > 0) {
+      return retryAfter * 1000;
+    }
+    return this.retryBaseDelayMs * 2 ** attempt;
+  }
 
   async fetch<RESP>(path: string, options: RequestInit = {}): Promise<RESP> {
     const headers: Record<string, string> = {
@@ -157,7 +186,19 @@ export class PortfolioManagerApi {
     const defaults = { method: "GET", headers } as RequestInit;
     const init: RequestInit = deepmerge({}, defaults, options);
     const url = this.endpoint + path;
-    const response = await fetch(url, init);
+    let response = await fetch(url, init);
+
+    // Retrying is safe even for POST/PUT: a rate-limited request is rejected
+    // before it is processed. Request bodies are strings, so they can be resent.
+    for (
+      let attempt = 0;
+      response.status === 429 && attempt < this.maxRetries;
+      attempt++
+    ) {
+      const delay = this.retryDelayMs(response, attempt);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      response = await fetch(url, init);
+    }
 
     // raise exception on 400-599 status codes
     if (response.status >= 400 && response.status < 600) {


### PR DESCRIPTION
## Problem

The ESPM API rate-limits requests, responding with `429 Too Many Requests` (`errorNumber="-200" errorDescription="Rate limit exceeded."`). `PortfolioManagerApi.fetch` treated 429 like any other error and threw immediately, so a single throttled request failed the whole operation — the direct cause of CI failures like [28718709747](https://github.com/dopry/portfolio-manager/actions/runs/28718709747), and the same failure any SDK consumer hits under load.

## Changes

- `PortfolioManagerApi.fetch` now retries 429 responses with exponential backoff (default: 3 retries starting at 1s, doubling each attempt).
- A numeric `Retry-After` header from the server takes precedence over the computed backoff.
- New optional `PortfolioManagerApiOptions` constructor argument (`maxRetries`, `retryBaseDelayMs`) — fully backward compatible; existing call sites are unchanged.
- Retrying POST/PUT is safe here: a rate-limited request is rejected before processing, and request bodies are strings so they can be resent.

## Tests

Three new unit tests (mocked fetch): retry-then-success, Retry-After honored (fake timers), and retry exhaustion rethrowing the 429. `npm run typecheck` and the unit suite pass; integration specs skip locally without credentials.

Companion to #35, which serializes the CI matrix so tests stop tripping the limit in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)