### PR TITLE
build: target ES2022, NodeNext module resolution, drop baseUrl

### DIFF
--- a/src/types/client/IClientConsumption.ts
+++ b/src/types/client/IClientConsumption.ts
@@ -1,3 +1,3 @@
-import { IMeterConsumption, IMeterDelivery } from "..";
+import { IMeterConsumption, IMeterDelivery } from "../index.js";
 
 export type IClientConsumption = IMeterDelivery | IMeterConsumption;

--- a/tsconfig.e2e.json
+++ b/tsconfig.e2e.json
@@ -1,15 +1,13 @@
 {
   // Typechecks the e2e suite (test/e2e is outside the build tsconfig's rootDir).
-  // Browser-automation code needs DOM types (page.evaluate callbacks) and
-  // top-level await (probe.ts), hence the lib/module/target overrides.
+  // Browser-automation code needs DOM types (page.evaluate callbacks), hence
+  // the lib override; module/target (NodeNext/ES2022) are inherited and
+  // support the top-level await in probe.ts.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
     "rootDir": ".",
-    "baseUrl": ".",
-    "lib": ["esnext", "dom", "dom.iterable"],
-    "module": "es2022",
-    "target": "es2022"
+    "lib": ["ES2023", "dom", "dom.iterable"]
   },
   "exclude": ["node_modules", "dist", "src/**/*.spec.ts"],
   "include": ["src", "test/e2e"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,16 +2,14 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    // base relative imports in src, TODO: implement paths instead
-    "baseUrl": "src",
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["esnext"],
+    "lib": ["ES2023"],
     "listEmittedFiles": false,
     "listFiles": false,
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "noFallthroughCasesInSwitch": true,
     "outDir": "dist",
     "pretty": true,
@@ -20,7 +18,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2015",
+    "target": "ES2022",
     "traceResolution": false,
     "types": [
       "node"


### PR DESCRIPTION
Quick win 2 from `plans/architecture-review-2026-07.md` (section B): align the compiler with the actual runtime floor.

## Changes

- **`target: ES2015` → `ES2022`.** The engine floor is Node >= 20; the old target down-leveled `async/await`, class fields, and spreads for runtimes the package doesn't support. Note this flips `useDefineForClassFields` to `true` — the CLI command subclasses (which declare `fields`/`defaultFields` as class fields on top of Commander's `Command`) were verified against this: all CLI specs pass and `--help` output still renders field defaults correctly.
- **`module`/`moduleResolution: NodeNext`.** The previous `moduleResolution: "node"` is the legacy CJS (node10) algorithm; it doesn't validate specifiers the way Node's ESM loader actually resolves them. NodeNext surfaced one real violation — a directory import (`from ".."`) in `src/types/client/IClientConsumption.ts` — fixed here.
- **`lib: ["esnext"]` → `["ES2023"]`** — pin to a released spec instead of a moving target.
- **Drop `baseUrl: "src"`** (resolves the existing TODO) — all imports are relative, and `tsconfig.e2e.json` drops its `baseUrl` override too.
- **`tsconfig.e2e.json`** no longer overrides `module`/`target` (NodeNext + ES2022 are inherited and support `probe.ts`'s top-level await); it keeps only `noEmit`, `rootDir`, and the DOM lib additions.

## Verification

- `npm run typecheck`, `npm run typecheck:e2e`, `npm run build`, `node dist/index.js --help` pass locally.
- All credential-free spec files pass locally (100 tests, 14 files); live integration runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_