### PR TITLE
feat: add package.json exports map, explicit types entry, and sideEffects flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,15 @@
   },
   "type": "module",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit -p tsconfig.json",


### PR DESCRIPTION
Quick win 3 from `plans/architecture-review-2026-07.md` (section A.1): lock down the package's public surface before 1.x stabilizes.

## Changes

- **`exports` map** with a `types` condition for the root entry, plus `"./package.json"` for tooling that resolves it. Deep imports into `dist/` stop being part of the public contract — semver-safe refactoring room.
- **Explicit `types: "dist/index.d.ts"`** instead of relying on TypeScript's implicit next-to-main convention.
- **`sideEffects: false`** so bundlers can tree-shake SDK consumers that don't touch the CLI classes. (The `shouldRunMain` guard in the entry is a no-op under import; the `bin` path doesn't involve bundler tree-shaking.)

The runtime `package.json` version read in `PortfolioManagerCommand.ts` uses a direct `file:` URL rather than module resolution, so it is unaffected by the exports map.

## Verification

- `npm run build` + `node dist/index.js --help` pass.
- `npx publint` (packs and lints the tarball): **All good!**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_