### PR TITLE
fix: await CLI actions via parseAsync and exit non-zero on failure

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -10,8 +10,8 @@ describe("src index entrypoint", () => {
     vi.resetModules();
   });
 
-  it("runs PortfolioManagerCommand.parse when module path matches argv[1]", async () => {
-    const parseSpy = vi.fn();
+  it("runs PortfolioManagerCommand.parseAsync when module path matches argv[1]", async () => {
+    const parseAsyncSpy = vi.fn().mockResolvedValue(undefined);
 
     vi.resetModules();
     vi.doMock("node:url", () => ({
@@ -19,7 +19,7 @@ describe("src index entrypoint", () => {
     }));
     vi.doMock("./cli/PortfolioManagerCommand.js", () => ({
       PortfolioManagerCommand: class {
-        parse = parseSpy;
+        parseAsync = parseAsyncSpy;
       },
     }));
 
@@ -33,11 +33,11 @@ describe("src index entrypoint", () => {
 
     await import("./index.js");
 
-    expect(parseSpy).toHaveBeenCalledWith(process.argv);
+    expect(parseAsyncSpy).toHaveBeenCalledWith(process.argv);
   });
 
-  it("does not run parse when module path does not match argv[1]", async () => {
-    const parseSpy = vi.fn();
+  it("does not run parseAsync when module path does not match argv[1]", async () => {
+    const parseAsyncSpy = vi.fn().mockResolvedValue(undefined);
 
     vi.resetModules();
     vi.doMock("node:url", () => ({
@@ -45,7 +45,7 @@ describe("src index entrypoint", () => {
     }));
     vi.doMock("./cli/PortfolioManagerCommand.js", () => ({
       PortfolioManagerCommand: class {
-        parse = parseSpy;
+        parseAsync = parseAsyncSpy;
       },
     }));
 
@@ -53,7 +53,63 @@ describe("src index entrypoint", () => {
 
     await import("./index.js");
 
-    expect(parseSpy).not.toHaveBeenCalled();
+    expect(parseAsyncSpy).not.toHaveBeenCalled();
+  });
+
+  it("prints the message and sets exitCode 1 when a command action rejects", async () => {
+    const originalExitCode = process.exitCode;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.resetModules();
+    vi.doMock("node:url", () => ({
+      fileURLToPath: vi.fn(() => "D:/src/dopry/portfolio-manager/src/index.ts"),
+    }));
+    vi.doMock("./cli/PortfolioManagerCommand.js", () => ({
+      PortfolioManagerCommand: class {
+        parseAsync = vi.fn().mockRejectedValue(new Error("action failed"));
+      },
+    }));
+
+    process.argv = ["node", "D:/src/dopry/portfolio-manager/src/index.ts"];
+
+    try {
+      await import("./index.js");
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith("action failed");
+      });
+      expect(process.exitCode).to.equal(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("stringifies non-Error rejections before printing them", async () => {
+    const originalExitCode = process.exitCode;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.resetModules();
+    vi.doMock("node:url", () => ({
+      fileURLToPath: vi.fn(() => "D:/src/dopry/portfolio-manager/src/index.ts"),
+    }));
+    vi.doMock("./cli/PortfolioManagerCommand.js", () => ({
+      PortfolioManagerCommand: class {
+        parseAsync = vi.fn().mockRejectedValue("plain string failure");
+      },
+    }));
+
+    process.argv = ["node", "D:/src/dopry/portfolio-manager/src/index.ts"];
+
+    try {
+      await import("./index.js");
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith("plain string failure");
+      });
+      expect(process.exitCode).to.equal(1);
+    } finally {
+      process.exitCode = originalExitCode;
+      errorSpy.mockRestore();
+    }
   });
 
   it("returns false for non-file import URLs", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,14 @@ import { PortfolioManagerCommand } from "./cli/PortfolioManagerCommand.js";
 
 async function main() {
   const cli = new PortfolioManagerCommand();
-  cli.parse(process.argv);
+  try {
+    // parseAsync (unlike parse) awaits async command actions, so a rejected
+    // action surfaces here instead of dying as an unhandled rejection.
+    await cli.parseAsync(process.argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }
 
 export function shouldRunMain(


### PR DESCRIPTION
Quick win 4 from `plans/architecture-review-2026-07.md` (section A.3): exit-code correctness for the CLI's shell-scripting audience.

## Problem

Command actions are `async` (`PortfolioManagerBaseCommand._action`), but the entry point called `cli.parse(process.argv)`, which does not await async handlers. A failing command (e.g. bad endpoint, auth failure) died as an unhandled rejection — a stack trace on stderr, and exit-code behavior left to Node's unhandled-rejection default rather than deliberate handling.

## Change

`main()` now awaits `cli.parseAsync(...)`; on rejection it prints the error message (or the stringified value for non-Error throws) and sets `process.exitCode = 1`. Commander's own `--help`/usage-error exits are unaffected.

Before:
```
$ portfolio-manager property list links --pm-endpoint https://bad-host/
<multi-line unhandled rejection stack trace>
```
After:
```
$ portfolio-manager property list links --pm-endpoint https://bad-host/
request to https://bad-host/account failed, reason: ...
$ echo $?
1
```

## Tests

`index.spec.ts` mocks updated from `parse` to `parseAsync`, plus two new tests covering the rejection path (Error and non-Error) asserting the printed message and `process.exitCode === 1`.

## Verification

- `npm run typecheck`, `npm run build` pass; `index.spec.ts` passes (6 tests).
- Manual check: failing command exits 1 with a single-line error; `--help` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_