### PR TITLE
fix: stop fetching the first consumption page twice in getMeterConsumption

### DIFF
--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -420,53 +420,39 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     const api = createMinimalMockApi();
     const pm = new PortfolioManager(api);
 
-    vi.mocked(api.meterConsumptionDataGet)
-      .mockResolvedValueOnce({
-        meterData: {
-          meterConsumption: [],
-          links: { link: [] },
+    vi.mocked(api.meterConsumptionDataGet).mockResolvedValueOnce({
+      meterData: {
+        meterConsumption: [],
+        links: {
+          link: [
+            {
+              "@_linkDescription": "next page",
+              "@_link": "/meter/1/consumptionData?page=bad",
+              "@_httpMethod": "GET",
+            },
+          ],
         },
-      } as never)
-      .mockResolvedValueOnce({
-        meterData: {
-          meterConsumption: [],
-          links: {
-            link: [
-              {
-                "@_linkDescription": "next page",
-                "@_link": "/meter/1/consumptionData?page=bad",
-                "@_httpMethod": "GET",
-              },
-            ],
-          },
-        },
-      } as never);
+      },
+    } as never);
 
     await expect(pm.getMeterConsumption(1)).rejects.toThrow(
       "Invalid next page link for meter 1"
     );
 
-    vi.mocked(api.meterConsumptionDataGet)
-      .mockResolvedValueOnce({
-        meterData: {
-          meterConsumption: [],
-          links: { link: [] },
+    vi.mocked(api.meterConsumptionDataGet).mockResolvedValueOnce({
+      meterData: {
+        meterConsumption: [],
+        links: {
+          link: [
+            {
+              "@_linkDescription": "next page",
+              "@_link": "/meter/1/consumptionData?page=",
+              "@_httpMethod": "GET",
+            },
+          ],
         },
-      } as never)
-      .mockResolvedValueOnce({
-        meterData: {
-          meterConsumption: [],
-          links: {
-            link: [
-              {
-                "@_linkDescription": "next page",
-                "@_link": "/meter/1/consumptionData?page=",
-                "@_httpMethod": "GET",
-              },
-            ],
-          },
-        },
-      } as never);
+      },
+    } as never);
     await expect(pm.getMeterConsumption(1)).rejects.toThrow(
       "Invalid next page link for meter 1"
     );
@@ -1035,12 +1021,6 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     vi.mocked(api.meterConsumptionDataGet)
       .mockResolvedValueOnce({
         meterData: {
-          meterDelivery: [{ quantity: 1 }],
-          links: { link: [] },
-        },
-      } as never)
-      .mockResolvedValueOnce({
-        meterData: {
           meterDelivery: [{ quantity: 2 }],
           links: {
             link: [
@@ -1064,6 +1044,9 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
       { quantity: 2 },
       { quantity: 5 },
     ]);
+    // The first page is fetched exactly once (previously a probe request
+    // duplicated it), and each subsequent page once.
+    expect(api.meterConsumptionDataGet).toHaveBeenCalledTimes(2);
 
     vi.mocked(api.meterConsumptionDataGet).mockResolvedValueOnce({ response: {} } as never);
     await expect(pm.getMeterConsumption(1)).rejects.toThrow("No meter consumption found");

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -260,18 +260,8 @@ export class PortfolioManager {
       return [];
     };
 
-    const response = await this.api.meterConsumptionDataGet(
-      meterId,
-      undefined,
-      startDate,
-      endDate
-    );
-    if (!response.meterData)
-      throw new Error(
-        `No meter consumption found:\n ${JSON.stringify(response, null, 2)}`
-      );
     const meterData: (IMeterDelivery | IMeterConsumption)[] = [];
-    let nextPage: number | typeof NaN | undefined = undefined;
+    let nextPage: number | undefined = undefined;
     do {
       const response = await this.api.meterConsumptionDataGet(
         meterId,
@@ -279,6 +269,10 @@ export class PortfolioManager {
         startDate,
         endDate
       );
+      if (!response.meterData)
+        throw new Error(
+          `No meter consumption found:\n ${JSON.stringify(response, null, 2)}`
+        );
       const page = getConsumptionRecordFromMeterData(response.meterData);
       meterData.push(...page);
 
@@ -292,7 +286,7 @@ export class PortfolioManager {
 
       const nextLinkUrl = nextLink ? nextLink["@_link"] : undefined;
       if (!nextLinkUrl) {
-        nextPage = NaN;
+        nextPage = undefined;
       } else {
         const nextPageStr = nextLinkUrl.split("=").pop() || "";
         const parsedNextPage = parseInt(nextPageStr, 10);
@@ -301,9 +295,8 @@ export class PortfolioManager {
         }
         nextPage = parsedNextPage;
       }
-    } while (!isNaN(nextPage));
+    } while (nextPage !== undefined);
     return meterData;
-    // there are more pages of results for this query
   }
 
   async getMeterLinks(


### PR DESCRIPTION
Quick win 5 from `plans/architecture-review-2026-07.md` (section E.1).

## Problem

`PortfolioManager.getMeterConsumption()` issued an initial request just to check that `response.meterData` exists, then entered its `do/while` pagination loop — whose first iteration (`nextPage = undefined`) re-issued the *identical* request. Every call fetched page 1 twice against an API rate-limited hard enough that CI serializes around it, and the probe response's actual data was thrown away.

The old test suite inadvertently documents the bug: it queued `{quantity: 1}` for the probe and asserted it never appeared in the result.

## Change

- The missing-`meterData` check moves inside the loop, so the first response is consumed as page 1. (This also means later pages get the same validation instead of crashing on undefined.)
- The `NaN` loop sentinel (`while (!isNaN(nextPage))`) is replaced with `undefined` and `while (nextPage !== undefined)`.
- The pagination test now asserts `toHaveBeenCalledTimes(2)` for a two-page fetch, so a duplicate-fetch regression fails the suite; the invalid-next-page-link tests drop their probe-response stubs.

Behavior is otherwise unchanged: same results, same errors, one fewer request per call (and half the requests for single-page meters).

## Verification

- `npm run typecheck` passes; all 3 synthetic `getMeterConsumption` tests pass locally.
- Live integration tests exercise the same path in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_