### PR TITLE
fix: widen RequestInit for duplex so typecheck:e2e passes with the DOM lib

### DIFF
--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -203,9 +203,12 @@ export class PortfolioManagerApi {
       headers: mergedHeaders,
     };
     // undici requires duplex: "half" for streaming request bodies and throws
-    // a TypeError otherwise (node-fetch had no such requirement).
-    if (init.body instanceof ReadableStream && init.duplex == null) {
-      init.duplex = "half";
+    // a TypeError otherwise (node-fetch had no such requirement). Widen the
+    // type locally: DOM's RequestInit (loaded by tsconfig.e2e.json's lib)
+    // does not declare duplex, unlike undici's.
+    const streamInit = init as RequestInit & { duplex?: "half" };
+    if (init.body instanceof ReadableStream && streamInit.duplex == null) {
+      streamInit.duplex = "half";
     }
     const url = this.endpoint + path;
     let response = await fetch(url, init);


### PR DESCRIPTION
Follow-up to #37, found while verifying #49: `npm run typecheck:e2e` is currently broken on `next`.

## Problem

`tsconfig.e2e.json` adds the DOM lib (needed for Playwright `page.evaluate` callbacks), and DOM's `RequestInit` type doesn't declare undici's `duplex` property — so the stream-body handling from the native-fetch migration fails the e2e typecheck. The main `typecheck` passes (no DOM lib), which is why per-push CI stayed green; the nightly e2e workflow's `typecheck:e2e` step would fail tonight.

## Change

Widen the type locally at the assignment site (`RequestInit & { duplex?: "half" }`). Runtime behavior is unchanged — the property was always set correctly; only the type resolution under the DOM lib differed.

## Verification

- `npm run typecheck` **and** `npm run typecheck:e2e` both pass (the latter failed before).
- `npm run lint`, `npm run build`, and the API spec (20 offline tests) pass.
- Written Prettier-clean so it composes with #49's `format:check` gate; merging this and #49 in either order is conflict-free (different lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_