### PR TITLE
refactor: consistent relative endpoint paths; forward RequestInit on post/put

### DIFF
--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1171,6 +1171,50 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     expect(tupleHeaders.get("content-type")).to.equal("application/xml");
   });
 
+  it("joins endpoint and path with or without a trailing slash", async () => {
+    fetchMock.mockImplementation(async () => {
+      return new Response("<response><status>Ok</status></response>", {
+        status: 200,
+        statusText: "OK",
+      });
+    });
+
+    await unitApi.fetch("property/1");
+    expect(fetchMock.mock.calls[0][0]).to.equal(
+      "https://example.test/property/1",
+    );
+
+    const noSlashApi = new PortfolioManagerApi(
+      "https://example.test",
+      "test-user",
+      "test-pass",
+    );
+    await noSlashApi.fetch("property/1");
+    expect(fetchMock.mock.calls[1][0]).to.equal(
+      "https://example.test/property/1",
+    );
+  });
+
+  it("post and put forward an AbortSignal to fetch", async () => {
+    fetchMock.mockImplementation(async () => {
+      return new Response("<response><status>Ok</status></response>", {
+        status: 200,
+        statusText: "OK",
+      });
+    });
+    const controller = new AbortController();
+
+    await unitApi.post("meter/1", { meter: {} }, { signal: controller.signal });
+    const postInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(postInit.signal).to.equal(controller.signal);
+    expect(postInit.method).to.equal("POST");
+
+    await unitApi.put("meter/1", { meter: {} }, { signal: controller.signal });
+    const putInit = fetchMock.mock.calls[1][1] as RequestInit;
+    expect(putInit.signal).to.equal(controller.signal);
+    expect(putInit.method).to.equal("PUT");
+  });
+
   it("post, put, and get delegate to fetch with expected init", async () => {
     const fetchSpy = vi.spyOn(unitApi, "fetch").mockResolvedValue({} as never);
 
@@ -1278,18 +1322,18 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     );
     await unitApi.meterConsumptionDataGet(10, 1, "2024-01-01", "2024-12-31");
 
-    expect(getSpy).toHaveBeenNthCalledWith(1, "/meter/10/consumptionData?");
+    expect(getSpy).toHaveBeenNthCalledWith(1, "meter/10/consumptionData");
     expect(getSpy).toHaveBeenNthCalledWith(
       2,
-      "/meter/10/consumptionData?page=2",
+      "meter/10/consumptionData?page=2",
     );
     expect(getSpy).toHaveBeenNthCalledWith(
       3,
-      "/meter/10/consumptionData?startDate=2024-01-01&endDate=2024-12-31",
+      "meter/10/consumptionData?startDate=2024-01-01&endDate=2024-12-31",
     );
     expect(getSpy).toHaveBeenNthCalledWith(
       4,
-      "/meter/10/consumptionData?page=1&startDate=2024-01-01&endDate=2024-12-31",
+      "meter/10/consumptionData?page=1&startDate=2024-01-01&endDate=2024-12-31",
     );
   });
 
@@ -1347,7 +1391,7 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     expect(getSpy).toHaveBeenCalledWith("meter/5/identifier/6");
     expect(getSpy).toHaveBeenCalledWith("meter/5/identifier/list");
     expect(getSpy).toHaveBeenCalledWith("meter/identifier/list");
-    expect(getSpy).toHaveBeenCalledWith("/association/property/8/meter");
+    expect(getSpy).toHaveBeenCalledWith("association/property/8/meter");
     expect(getSpy).toHaveBeenCalledWith(
       "property/10/meter/list?myAccessOnly=false",
     );
@@ -1355,10 +1399,10 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
       "property/10/meter/list?myAccessOnly=true",
     );
     expect(getSpy).toHaveBeenCalledWith(
-      "/property/11/design/metrics?measurementSystem=EPA",
+      "property/11/design/metrics?measurementSystem=EPA",
     );
     expect(getSpy).toHaveBeenCalledWith(
-      "/property/11/design/metrics?measurementSystem=METRIC",
+      "property/11/design/metrics?measurementSystem=METRIC",
     );
     expect(getSpy).toHaveBeenCalledWith("customer/list");
 
@@ -1375,7 +1419,7 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
       meter: { name: "M" },
     });
     expect(postSpy).toHaveBeenCalledWith(
-      "/association/property/8/meter/9",
+      "association/property/8/meter/9",
       undefined,
     );
 

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1193,6 +1193,12 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     expect(fetchMock.mock.calls[1][0]).to.equal(
       "https://example.test/property/1",
     );
+
+    // fetch() is public API: a legacy leading-slash path still joins cleanly.
+    await noSlashApi.fetch("/property/1");
+    expect(fetchMock.mock.calls[2][0]).to.equal(
+      "https://example.test/property/1",
+    );
   });
 
   it("post and put forward an AbortSignal to fetch", async () => {

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -210,11 +210,13 @@ export class PortfolioManagerApi {
     if (init.body instanceof ReadableStream && streamInit.duplex == null) {
       streamInit.duplex = "half";
     }
-    // Path convention: endpoint paths are relative (no leading slash);
+    // Path convention: endpoint paths are relative (no leading slash), but
+    // fetch() is public API, so strip a legacy leading slash defensively;
     // tolerate endpoints configured with or without a trailing slash.
+    const relativePath = path.startsWith("/") ? path.slice(1) : path;
     const url = this.endpoint.endsWith("/")
-      ? this.endpoint + path
-      : `${this.endpoint}/${path}`;
+      ? this.endpoint + relativePath
+      : `${this.endpoint}/${relativePath}`;
     let response = await fetch(url, init);
 
     // Retrying is safe even for POST/PUT: a rate-limited request is rejected

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -210,7 +210,11 @@ export class PortfolioManagerApi {
     if (init.body instanceof ReadableStream && streamInit.duplex == null) {
       streamInit.duplex = "half";
     }
-    const url = this.endpoint + path;
+    // Path convention: endpoint paths are relative (no leading slash);
+    // tolerate endpoints configured with or without a trailing slash.
+    const url = this.endpoint.endsWith("/")
+      ? this.endpoint + path
+      : `${this.endpoint}/${path}`;
     let response = await fetch(url, init);
 
     // Retrying is safe even for POST/PUT: a rate-limited request is rejected
@@ -262,22 +266,26 @@ export class PortfolioManagerApi {
     }
   }
 
-  async post<REQ, RESP>(path: string, data: REQ): Promise<RESP> {
+  /** Options (e.g. an AbortSignal) are forwarded; method and body win. */
+  async post<REQ, RESP>(
+    path: string,
+    data: REQ,
+    options: RequestInit = {},
+  ): Promise<RESP> {
     const builder = new XMLBuilder(this.xmlBuilderOptions);
-    const xmlData: string = builder.build(data);
-    const method = "POST";
-    const body: string = xmlData;
-    const init: RequestInit = { method, body };
-    return await this.fetch<RESP>(path, init);
+    const body: string = builder.build(data);
+    return await this.fetch<RESP>(path, { ...options, method: "POST", body });
   }
 
-  async put<REQ, RESP>(path: string, data: REQ): Promise<RESP> {
+  /** Options (e.g. an AbortSignal) are forwarded; method and body win. */
+  async put<REQ, RESP>(
+    path: string,
+    data: REQ,
+    options: RequestInit = {},
+  ): Promise<RESP> {
     const builder = new XMLBuilder(this.xmlBuilderOptions);
-    const xmlData: string = builder.build(data);
-    const method = "PUT";
-    const body: string = xmlData;
-    const init: RequestInit = { method, body };
-    return await this.fetch<RESP>(path, init);
+    const body: string = builder.build(data);
+    return await this.fetch<RESP>(path, { ...options, method: "PUT", body });
   }
 
   async get<RESP>(path: string, options: RequestInit = {}): Promise<RESP> {
@@ -429,7 +437,7 @@ export class PortfolioManagerApi {
     propertyId: number,
   ): Promise<IMeterPropertyAssociationGetResponse> {
     return this.get<IMeterPropertyAssociationGetResponse>(
-      `/association/property/${propertyId}/meter`,
+      `association/property/${propertyId}/meter`,
     );
   }
 
@@ -439,7 +447,7 @@ export class PortfolioManagerApi {
     meterId: number,
   ): Promise<IMeterPropertyAssociationPostResponse> {
     return this.post<undefined, IMeterPropertyAssociationPostResponse>(
-      `/association/property/${propertyId}/meter/${meterId}`,
+      `association/property/${propertyId}/meter/${meterId}`,
       undefined,
     );
   }
@@ -478,7 +486,8 @@ export class PortfolioManagerApi {
     if (endDate) {
       args.push(`endDate=${endDate}`);
     }
-    const url = `/meter/${meterId}/consumptionData?${args.join("&")}`;
+    const query = args.length > 0 ? `?${args.join("&")}` : "";
+    const url = `meter/${meterId}/consumptionData${query}`;
     return this.get<IMeterConsumptionDataGetResponse>(url);
   }
 
@@ -502,7 +511,7 @@ export class PortfolioManagerApi {
     propertyId: number,
     measurementSystem: MeasurementSystem = "EPA",
   ): Promise<IPropertyDesignMetricsGetResponse> {
-    const url = `/property/${propertyId}/design/metrics?measurementSystem=${measurementSystem}`;
+    const url = `property/${propertyId}/design/metrics?measurementSystem=${measurementSystem}`;
 
     return this.get<IPropertyDesignMetricsGetResponse>(url);
   }
@@ -529,7 +538,7 @@ export class PortfolioManagerApi {
         "PM-Metrics": metrics.join(","),
       },
     };
-    const url = `/property/${propertyId}/metrics?${args.join("&")}`;
+    const url = `property/${propertyId}/metrics?${args.join("&")}`;
     return this.get<IPropertyMetricsGetResponse>(url, options);
   }
 
@@ -555,7 +564,7 @@ export class PortfolioManagerApi {
         "PM-Metrics": metrics.join(","),
       },
     };
-    const url = `/property/${propertyId}/metrics/monthly?${args.join("&")}`;
+    const url = `property/${propertyId}/metrics/monthly?${args.join("&")}`;
     return this.get<IPropertyMetricsMonthlyGetResponse>(url, options);
   }
 
@@ -582,8 +591,8 @@ export class PortfolioManagerApi {
     page?: number,
   ): Promise<IGetPendingConnectionsResponse> {
     const url = page
-      ? `/connect/account/pending/list?page=${page}`
-      : "/connect/account/pending/list";
+      ? `connect/account/pending/list?page=${page}`
+      : "connect/account/pending/list";
     return this.get<IGetPendingConnectionsResponse>(url);
   }
 
@@ -593,7 +602,7 @@ export class PortfolioManagerApi {
     body: ISharingResponsePayload,
   ): Promise<ISharingActionResponse> {
     return this.post<ISharingResponsePayload, ISharingActionResponse>(
-      `/connect/account/${accountId}`,
+      `connect/account/${accountId}`,
       body,
     );
   }
@@ -604,7 +613,7 @@ export class PortfolioManagerApi {
     body: ITerminateSharingResponsePayload,
     keepShares: boolean = false,
   ): Promise<ISharingActionResponse> {
-    const url = `/disconnect/account/${accountId}?keepShares=${keepShares}`;
+    const url = `disconnect/account/${accountId}?keepShares=${keepShares}`;
     return this.post<ITerminateSharingResponsePayload, ISharingActionResponse>(
       url,
       body,
@@ -616,8 +625,8 @@ export class PortfolioManagerApi {
     page?: number,
   ): Promise<IGetPendingPropertySharesResponse> {
     const url = page
-      ? `/share/property/pending/list?page=${page}`
-      : "/share/property/pending/list";
+      ? `share/property/pending/list?page=${page}`
+      : "share/property/pending/list";
     return this.get<IGetPendingPropertySharesResponse>(url);
   }
 
@@ -627,7 +636,7 @@ export class PortfolioManagerApi {
     body: ISharingResponsePayload,
   ): Promise<ISharingActionResponse> {
     return this.post<ISharingResponsePayload, ISharingActionResponse>(
-      `/share/property/${propertyId}`,
+      `share/property/${propertyId}`,
       body,
     );
   }
@@ -637,8 +646,8 @@ export class PortfolioManagerApi {
     page?: number,
   ): Promise<IGetPendingMeterSharesResponse> {
     const url = page
-      ? `/share/meter/pending/list?page=${page}`
-      : "/share/meter/pending/list";
+      ? `share/meter/pending/list?page=${page}`
+      : "share/meter/pending/list";
     return this.get<IGetPendingMeterSharesResponse>(url);
   }
 
@@ -648,7 +657,7 @@ export class PortfolioManagerApi {
     body: ISharingResponsePayload,
   ): Promise<ISharingActionResponse> {
     return this.post<ISharingResponsePayload, ISharingActionResponse>(
-      `/share/meter/${meterId}`,
+      `share/meter/${meterId}`,
       body,
     );
   }
@@ -659,7 +668,7 @@ export class PortfolioManagerApi {
     body: ITerminateSharingResponsePayload,
   ): Promise<ISharingActionResponse> {
     return this.post<ITerminateSharingResponsePayload, ISharingActionResponse>(
-      `/unshare/property/${propertyId}`,
+      `unshare/property/${propertyId}`,
       body,
     );
   }
@@ -670,7 +679,7 @@ export class PortfolioManagerApi {
     body: ITerminateSharingResponsePayload,
   ): Promise<ISharingActionResponse> {
     return this.post<ITerminateSharingResponsePayload, ISharingActionResponse>(
-      `/unshare/meter/${meterId}`,
+      `unshare/meter/${meterId}`,
       body,
     );
   }
@@ -680,7 +689,7 @@ export class PortfolioManagerApi {
     clear: boolean = true,
   ): Promise<IGetNotificationListResponse> {
     return this.get<IGetNotificationListResponse>(
-      `/notification/list?clear=${clear}`,
+      `notification/list?clear=${clear}`,
     );
   }
   /* c8 ignore stop */


### PR DESCRIPTION
Review items D.1 + D.2 from `plans/architecture-review-2026-07.md`, scoped per maintainer direction: consistency **by convention** rather than a URL-builder layer, abort support **without** a default timeout, and D.3 (injectable fetch) dropped as complexity without demand.

## D.1 — path convention

- All ~20 endpoint paths that carried a leading slash now uniformly omit it, matching `"account"`/`"customer/list"`. Previously `"https://…/wstest/" + "/meter/…"` produced `wstest//meter`, which only worked because the server tolerated it.
- `fetch()` documents the convention and joins endpoint+path correctly whether `PM_ENDPOINT` is configured with or without a trailing slash — both forms were previously half-broken depending on which endpoint method you hit.
- `meterConsumptionDataGet` no longer emits a dangling `?` when called with no optional params.
- No `URL`/`URLSearchParams` layer: the query values on this API are numbers, ISO dates, and fixed enums, so an encoding layer would be machinery for inputs that can't occur.

## D.2 — abort passthrough

`post()` and `put()` now accept an optional `RequestInit` forwarded to `fetch()` (with `method`/`body` always winning), so callers can pass an `AbortSignal` for mutations the way `get()`/`delete()` already allowed. No default timeout — cancellation is entirely caller-driven.

## Tests

- New: endpoint joining with and without trailing slash asserts exact URLs (no double slash); `post`/`put` forward the caller's signal.
- Updated: the path-shape assertions in the existing delegation tests reflect the new convention.

## Verification

`lint`, `format:check`, `typecheck`, `build`, CLI smoke pass; API spec 22/22 offline tests green. Live integration exercises every endpoint path in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_