### PR TITLE
feat: injectable logger for facade error reporting, console by default

### DIFF
--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -535,6 +535,29 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     );
   });
 
+  it("routes facade error logging through an injected logger", async () => {
+    const api = createMinimalMockApi();
+    const logged: unknown[][] = [];
+    const pm = new PortfolioManager(api, {
+      logger: {
+        error: (...args: unknown[]) => {
+          logged.push(args);
+        },
+      },
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.spyOn(pm, "getAssociatedMeters").mockRejectedValue(
+      new Error("assoc failed"),
+    );
+    await expect(pm.getMetersPropertiesAssociation([1])).resolves.toEqual([]);
+
+    expect(logged.length).to.equal(1);
+    expect(logged[0][0]).to.equal("Error getting meter property association");
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   it("getProperties caps fan-out at the configured concurrency", async () => {
     const api = createMinimalMockApi();
     const pm = new PortfolioManager(api, { concurrency: 2 });

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -554,6 +554,9 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
 
     expect(logged.length).to.equal(1);
     expect(logged[0][0]).to.equal("Error getting meter property association");
+    // The rejection reason is forwarded as the second argument.
+    expect(logged[0][1]).to.be.instanceOf(Error);
+    expect((logged[0][1] as Error).message).to.equal("assoc failed");
     expect(consoleSpy).not.toHaveBeenCalled();
     consoleSpy.mockRestore();
   });

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -535,6 +535,13 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     );
   });
 
+  it("rejects a logger without an error method at construction", () => {
+    const api = createMinimalMockApi();
+    expect(() => new PortfolioManager(api, { logger: {} as never })).toThrow(
+      "Invalid logger option",
+    );
+  });
+
   it("routes facade error logging through an injected logger", async () => {
     const api = createMinimalMockApi();
     const logged: unknown[][] = [];

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -57,16 +57,25 @@ export interface PortfolioManagerOptions {
    * so unbounded fan-out over large accounts trips 429s. Defaults to 5.
    */
   concurrency?: number;
+  /**
+   * Sink for facade error logging (partial failures in fan-outs, unexpected
+   * response shapes). Defaults to console, which suits stdout/stderr log
+   * collection in containerized deployments; inject a custom sink to
+   * redirect or silence it.
+   */
+  logger?: Pick<Console, "error">;
 }
 
 export class PortfolioManager {
   protected _accountPromise: Promise<IAccount> | undefined;
   protected readonly concurrency: number;
+  protected readonly logger: Pick<Console, "error">;
 
   constructor(
     protected api: PortfolioManagerApi,
     options: PortfolioManagerOptions = {},
   ) {
+    this.logger = options.logger ?? console;
     const concurrency = options.concurrency ?? 5;
     // Fail fast on misconfiguration instead of erroring later inside the
     // first fan-out call.
@@ -275,7 +284,7 @@ export class PortfolioManager {
       if (isIDeliveryMeterData(meterData)) {
         return meterData.meterDelivery;
       }
-      console.error(
+      this.logger.error(
         `Unable to determine meter consumption type returning an empty array`,
         { meterId, startDate, endDate, meterData },
       );
@@ -445,7 +454,7 @@ export class PortfolioManager {
         try {
           return await this.getAssociatedMeters(propertyId);
         } catch (reason) {
-          console.error("Error getting meter property association", reason);
+          this.logger.error("Error getting meter property association", reason);
           return undefined;
         }
       },

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -75,7 +75,13 @@ export class PortfolioManager {
     protected api: PortfolioManagerApi,
     options: PortfolioManagerOptions = {},
   ) {
-    this.logger = options.logger ?? console;
+    const logger = options.logger ?? console;
+    if (typeof logger.error !== "function") {
+      throw new Error(
+        "Invalid logger option: expected an object with an error method",
+      );
+    }
+    this.logger = logger;
     const concurrency = options.concurrency ?? 5;
     // Fail fast on misconfiguration instead of erroring later inside the
     // first fan-out call.


### PR DESCRIPTION
Review item E.4 from `plans/architecture-review-2026-07.md`, scoped per maintainer direction: **non-breaking, console as the default** (containerized deployments collect stdout/stderr, so default behavior must not change).

## Changes

- `PortfolioManagerOptions` gains `logger?: Pick<Console, "error">`, defaulting to `console`. The two facade sites that wrote directly to `console.error` — the unknown-meterData-shape fallback in `getMeterConsumption()` and the log-and-skip catch in `getMetersPropertiesAssociation()` — now route through it.
- The interface is deliberately minimal (`error` only — the single method actually used); it widens compatibly if `warn`/`info` are ever needed, and any `Console`-shaped logger (pino/winston wrappers included) satisfies it.
- Composes with the existing `concurrency` option on the same options object from #52.

Out of scope, per earlier discussion: changing `getMetersPropertiesAssociation`'s drop-on-failure semantics — that's a return-shape question batched with the deferred breaking-surface work.

## Tests

New synthetic test: an injected logger receives the association-failure log (message + reason) while `console.error` stays untouched. Existing tests spying `console.error` continue to pass against the default, proving default behavior is unchanged.

## Verification

`lint`, `format:check`, `typecheck`, `build` pass; synthetic facade suite 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_