### PR TITLE
fix: accept fast-xml-parser 5.9 isArray callback signature

### DIFF
--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -109,8 +109,11 @@ export class PortfolioManagerApi {
     // fast-xml-parser collapses single-occurrence elements to plain
     // objects; ARRAY_JPATHS (generated from the vendored XSDs by
     // `npm run generate:xml`) pins every schema-repeatable element to
-    // array shape so responses parse consistently.
-    isArray: (_name, jpath): boolean => ARRAY_JPATHS.has(jpath),
+    // array shape so responses parse consistently. Since fxp 5.9 the
+    // callback receives a MatcherView instead of a string when the
+    // jPath option is off; stringifying covers both (MatcherView's
+    // toString() yields the dotted jpath).
+    isArray: (_name, jpath): boolean => ARRAY_JPATHS.has(String(jpath)),
   };
   xmlBuilderOptions: Partial<XmlBuilderOptions> = {
     ignoreAttributes: false,


### PR DESCRIPTION
Standalone fix for the typecheck failure that surfaced on #47 after dependabot rebased it onto post-codegen `next`.

## Problem

fast-xml-parser 5.9 widened the `isArray` callback's jpath parameter from `string` to `string | MatcherView` (a `MatcherView` arrives when the new `jPath` option is set to `false`; the default `jPath: true` still passes the dotted string at runtime — which is why the test suites pass while `tsc` fails). `ARRAY_JPATHS.has(jpath)` no longer typechecks against a `ReadonlySet<string>` under 5.9.x typings.

## Fix

Stringify the parameter before the set lookup: `ARRAY_JPATHS.has(String(jpath))`. This compiles and behaves identically under both 5.4.x and 5.9.x — `MatcherView#toString()` yields the dotted jpath. It is the only call site that uses the jpath parameter (the `tagValueProcessor` and the codegen script only use the tag name).

## Sequencing

Landing this on `next` first lets #47 rebase cleanly and go green without carrying a manual commit (which stops dependabot's auto-rebase). Once this merges, comment `·@·d·ependabot r·ebase` on #47 — that will discard the equivalent fix commit (bbb4e51) I had pushed to its branch and rebase onto a `next` that already compiles under either version.

## Verification

Typecheck, lint, format, build, and offline suites (119 + 37) verified green under **both** fxp 5.4.2 (this branch's lockfile) and 5.9.3 (on #47's branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_