### PR TITLE
fix: skip the XML builder for body-less POST/PUT requests

### DIFF
--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -850,6 +850,26 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     expect(isPortfolioManagerApiError({})).to.equal(false);
   });
 
+  it("post sends no body for body-less endpoints", async () => {
+    // fast-xml-parser >= 5.7 delegates to fast-xml-builder, whose build()
+    // throws on undefined input where older versions returned "" — so
+    // body-less endpoints must bypass the builder entirely.
+    fetchMock.mockResolvedValue(
+      new Response('<response status="Ok" />', {
+        status: 200,
+        statusText: "OK",
+      }),
+    );
+
+    await expect(
+      unitApi.meterPropertyAssociationSinglePost(1, 2),
+    ).resolves.toBeTruthy();
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init?.method).to.equal("POST");
+    expect(init?.body).to.equal(undefined);
+  });
+
   it("fetch throws PortfolioManagerApiError on 5xx responses", async () => {
     fetchMock.mockResolvedValue(
       new Response("<response status='Error' />", {

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -254,14 +254,27 @@ export class PortfolioManagerApi {
     }
   }
 
+  /**
+   * Some endpoints (e.g. meter/property association, sample properties)
+   * take no request body — the whole operation is expressed in the URL.
+   * fast-xml-parser >= 5.7 delegates building to fast-xml-builder, whose
+   * build() throws on nullish input where older versions returned "", so
+   * body-less requests must skip the builder entirely (an absent body and
+   * an empty body are equivalent on the wire).
+   */
+  private buildBody(data: unknown): string | undefined {
+    if (data == null) return undefined;
+    const builder = new XMLBuilder(this.xmlBuilderOptions);
+    return builder.build(data) as string;
+  }
+
   /** Options (e.g. an AbortSignal) are forwarded; method and body win. */
   async post<REQ, RESP>(
     path: string,
     data: REQ,
     options: RequestInit = {},
   ): Promise<RESP> {
-    const builder = new XMLBuilder(this.xmlBuilderOptions);
-    const body: string = builder.build(data);
+    const body = this.buildBody(data);
     return await this.fetch<RESP>(path, { ...options, method: "POST", body });
   }
 
@@ -271,8 +284,7 @@ export class PortfolioManagerApi {
     data: REQ,
     options: RequestInit = {},
   ): Promise<RESP> {
-    const builder = new XMLBuilder(this.xmlBuilderOptions);
-    const body: string = builder.build(data);
+    const body = this.buildBody(data);
     return await this.fetch<RESP>(path, { ...options, method: "PUT", body });
   }
 


### PR DESCRIPTION
Second hidden impact of the fast-xml-parser 5.9.3 bump (#47), surfaced by the credentialed integration jobs after #59 fixed the typecheck: [`test (node 22)`](https://github.com/dopry/portfolio-manager/actions/runs/28879716555/job/85664319497?pr=47) failed with

```
TypeError: Cannot read properties of undefined (reading '?xml')
  ❯ detectXmlVersionFromObj node_modules/fast-xml-builder/src/fxb.js:109
  ❯ PortfolioManagerApi.post src/PortfolioManagerApi.ts:264
```

## Problem

`meterPropertyAssociationSinglePost` and `createSampleProperties` POST **no request body** — the operation is expressed entirely in the URL — so they pass `data: undefined` into `builder.build()`. fxp ≤ 5.6's built-in builder returned `""` for nullish input; fxp ≥ 5.7 delegates to the extracted `fast-xml-builder` package, whose `build()` dereferences the input (`jObj['?xml']`) during XML-version detection and throws.

## Fix

`post()`/`put()` now go through a `buildBody` helper that returns `undefined` for nullish data and only instantiates the builder otherwise. An absent body and an empty body are equivalent on the wire, so behavior under fxp 5.4.x is unchanged.

## Why offline CI never caught it

Both affected endpoints were exercised only by credentialed integration tests. The new unit regression test stubs `fetch` and asserts the association POST resolves and sends no body — it reproduces the exact integration failure without credentials (verified: fails with the same TypeError on pre-fix code under 5.9.3, passes post-fix).

## Verification

Typecheck, lint, format, build, and offline suites verified green under **both** fxp 5.4.2 (this branch's lockfile) and 5.9.3 (`npm i --no-save`), 120 + 37 tests.

Sequencing: merge this before #47 (same pattern as #59), then #47 should go fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP

---
_Generated by [Claude Code](https://claude.ai/code/session_013QUiPsWdB3zNFFWfdogiSP)_