### PR TITLE
feat: support What's Changed API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ const propertyUses = await api.propertyUseGetWhatChangedGet(100, "2024-01-01", {
 const meters = await api.meterGetWhatChangedGet(100, "2024-01-01");
 ```
 
+The `PortfolioManager` facade maps all paginated links to IDs and defaults to
+the current account. Pass a customer ID only when querying an alternate
+account.
+
+```typescript
+const propertyIds = await pm.getChangedPropertyIds("2024-01-01");
+const propertyUseIds = await pm.getChangedPropertyUseIds("2024-01-01");
+const meterIds = await pm.getChangedMeterIds("2024-01-01");
+
+const alternateCustomerPropertyIds = await pm.getChangedPropertyIds(
+  "2024-01-01",
+  100,
+);
+```
+
 ### Interfaces
 
 ```typescript
@@ -143,6 +158,18 @@ class PortfolioManager {
   async getProperty(propertyId: number): Promise<IClientProperty>;
   async getPropertyLinks(accountId?: number): Promise<ILink[]>;
   async getProperties(accountId?: number): Promise<IClientProperty[]>;
+  async getChangedPropertyIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]>;
+  async getChangedPropertyUseIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]>;
+  async getChangedMeterIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]>;
 }
 
 class PortfolioManagerApi {

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ async function main() {
 main();
 ```
 
+### What's Changed
+
+The typed API gateway supports ENERGY STAR's property, property-use, and meter
+What's Changed calls. Dates use the `YYYY-MM-DD` format, and the optional page
+keys are the opaque cursor values returned by Portfolio Manager.
+
+```typescript
+const properties = await api.propertyGetWhatChangedGet(100, "2024-01-01");
+const propertyUses = await api.propertyUseGetWhatChangedGet(100, "2024-01-01", {
+  nextPageKey: "3000",
+});
+const meters = await api.meterGetWhatChangedGet(100, "2024-01-01");
+```
+
 ### Interfaces
 
 ```typescript

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -421,6 +421,9 @@ function createExtendedMockApi(): PortfolioManagerApi {
     propertyPropertyDelete: vi.fn(),
     propertyPropertyGet: vi.fn(),
     propertyPropertyListGet: vi.fn(),
+    propertyGetWhatChangedGet: vi.fn(),
+    propertyUseGetWhatChangedGet: vi.fn(),
+    meterGetWhatChangedGet: vi.fn(),
     propertyMetricsMonthlyGet: vi.fn(),
     propertyMetricsGet: vi.fn(),
     connectAccountPendingListGet: vi.fn(),
@@ -622,6 +625,157 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     await expect(pm.getProperties(1)).resolves.toEqual([{ id: 6 }]);
     await expect(pm.getProperties(1)).rejects.toThrow(
       "Invalid property id in link",
+    );
+  });
+
+  it("getChangedPropertyIds defaults to the current account and drains cursor pages", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+
+    vi.mocked(api.accountAccountGet).mockResolvedValueOnce({
+      account: { id: 77 },
+    } as never);
+    vi.mocked(api.propertyGetWhatChangedGet)
+      .mockResolvedValueOnce({
+        response: {
+          "@_status": "Ok",
+          links: {
+            link: [
+              {
+                "@_id": "5",
+                "@_link": "/property/5",
+                "@_linkDescription": "This is the GET url for this Property.",
+                "@_httpMethod": "GET",
+              },
+              {
+                "@_link":
+                  "/customer/77/property/whatChanged?nextPageKey=opaque%2Fkey%2B1&date=2024-01-01",
+                "@_linkDescription": "next page",
+                "@_httpMethod": "GET",
+              },
+            ],
+          },
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        response: {
+          "@_status": "Ok",
+          links: {
+            link: [
+              {
+                "@_id": "6",
+                "@_link": "/property/6",
+                "@_linkDescription": "This is the GET url for this Property.",
+                "@_httpMethod": "GET",
+              },
+              {
+                "@_link":
+                  "/customer/77/property/whatChanged?previousPageKey=opaque%2Fkey%2B0&date=2024-01-01",
+                "@_linkDescription": "previous page",
+                "@_httpMethod": "GET",
+              },
+            ],
+          },
+        },
+      } as never);
+
+    await expect(pm.getChangedPropertyIds("2024-01-01")).resolves.toEqual([
+      5, 6,
+    ]);
+    expect(api.accountAccountGet).toHaveBeenCalledTimes(1);
+    expect(api.propertyGetWhatChangedGet).toHaveBeenNthCalledWith(
+      1,
+      77,
+      "2024-01-01",
+      {},
+    );
+    expect(api.propertyGetWhatChangedGet).toHaveBeenNthCalledWith(
+      2,
+      77,
+      "2024-01-01",
+      { nextPageKey: "opaque/key+1" },
+    );
+  });
+
+  it("getChangedPropertyUseIds and getChangedMeterIds accept a customer override", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+
+    vi.mocked(api.propertyUseGetWhatChangedGet).mockResolvedValueOnce({
+      response: { "@_status": "Ok", links: "" },
+    } as never);
+    vi.mocked(api.meterGetWhatChangedGet).mockResolvedValueOnce({
+      response: {
+        "@_status": "Ok",
+        links: {
+          link: [
+            {
+              "@_id": "9",
+              "@_link": "/meter/9",
+              "@_linkDescription": "This is the GET url for this Meter.",
+              "@_httpMethod": "GET",
+            },
+          ],
+        },
+      },
+    } as never);
+
+    await expect(
+      pm.getChangedPropertyUseIds("2024-01-01", 88),
+    ).resolves.toEqual([]);
+    await expect(pm.getChangedMeterIds("2024-01-01", 88)).resolves.toEqual([9]);
+    expect(api.accountAccountGet).not.toHaveBeenCalled();
+    expect(api.propertyUseGetWhatChangedGet).toHaveBeenCalledWith(
+      88,
+      "2024-01-01",
+      {},
+    );
+    expect(api.meterGetWhatChangedGet).toHaveBeenCalledWith(
+      88,
+      "2024-01-01",
+      {},
+    );
+  });
+
+  it("getChanged ID collection rejects malformed entity and pagination links", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+
+    vi.mocked(api.propertyGetWhatChangedGet).mockResolvedValueOnce({
+      response: {
+        "@_status": "Ok",
+        links: {
+          link: [
+            {
+              "@_id": "bad",
+              "@_link": "/property/bad",
+              "@_linkDescription": "This is the GET url for this Property.",
+              "@_httpMethod": "GET",
+            },
+          ],
+        },
+      },
+    } as never);
+    vi.mocked(api.meterGetWhatChangedGet).mockResolvedValueOnce({
+      response: {
+        "@_status": "Ok",
+        links: {
+          link: [
+            {
+              "@_link": "/customer/88/meter/whatChanged?date=2024-01-01",
+              "@_linkDescription": "next page",
+              "@_httpMethod": "GET",
+            },
+          ],
+        },
+      },
+    } as never);
+
+    await expect(pm.getChangedPropertyIds("2024-01-01", 88)).rejects.toThrow(
+      "Invalid property id in What's Changed link",
+    );
+    await expect(pm.getChangedMeterIds("2024-01-01", 88)).rejects.toThrow(
+      "Invalid next page link for meter What's Changed results",
     );
   });
 

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -770,6 +770,20 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
         },
       },
     } as never);
+    vi.mocked(api.propertyUseGetWhatChangedGet).mockResolvedValueOnce({
+      response: {
+        "@_status": "Ok",
+        links: {
+          link: [
+            {
+              "@_link": "http://[",
+              "@_linkDescription": "next page",
+              "@_httpMethod": "GET",
+            },
+          ],
+        },
+      },
+    } as never);
 
     await expect(pm.getChangedPropertyIds("2024-01-01", 88)).rejects.toThrow(
       "Invalid property id in What's Changed link",
@@ -777,6 +791,37 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     await expect(pm.getChangedMeterIds("2024-01-01", 88)).rejects.toThrow(
       "Invalid next page link for meter What's Changed results",
     );
+    await expect(pm.getChangedPropertyUseIds("2024-01-01", 88)).rejects.toThrow(
+      "Invalid next page link for property use What's Changed results",
+    );
+  });
+
+  it("getChanged ID collection rejects repeated pagination cursors", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+    const repeatedNextPage = {
+      response: {
+        "@_status": "Ok",
+        links: {
+          link: [
+            {
+              "@_link":
+                "/customer/88/property/whatChanged?date=2024-01-01&nextPageKey=repeat",
+              "@_linkDescription": "next page",
+              "@_httpMethod": "GET",
+            },
+          ],
+        },
+      },
+    } as never;
+    vi.mocked(api.propertyGetWhatChangedGet)
+      .mockResolvedValueOnce(repeatedNextPage)
+      .mockResolvedValueOnce(repeatedNextPage);
+
+    await expect(pm.getChangedPropertyIds("2024-01-01", 88)).rejects.toThrow(
+      "Repeated next page key for property What's Changed results: repeat",
+    );
+    expect(api.propertyGetWhatChangedGet).toHaveBeenCalledTimes(2);
   });
 
   it("getAccountId + getMeter throw when payloads are missing required objects", async () => {

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -557,6 +557,7 @@ export class PortfolioManager {
     ) => Promise<IGetWhatChangedResponse>,
   ): Promise<number[]> {
     const ids: number[] = [];
+    const seenPageKeys = new Set<string>();
     let nextPageKey: string | undefined;
 
     do {
@@ -602,16 +603,29 @@ export class PortfolioManager {
         continue;
       }
 
-      const nextUrl = new URL(
-        nextLink["@_link"],
-        "https://portfoliomanager.energystar.gov",
-      );
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(
+          nextLink["@_link"],
+          "https://portfoliomanager.energystar.gov",
+        );
+      } catch {
+        throw new Error(
+          `Invalid next page link for ${resourceName} What's Changed results: ${nextLink["@_link"]}`,
+        );
+      }
       const cursor = nextUrl.searchParams.get("nextPageKey");
       if (!cursor) {
         throw new Error(
           `Invalid next page link for ${resourceName} What's Changed results: ${nextLink["@_link"]}`,
         );
       }
+      if (seenPageKeys.has(cursor)) {
+        throw new Error(
+          `Repeated next page key for ${resourceName} What's Changed results: ${cursor}`,
+        );
+      }
+      seenPageKeys.add(cursor);
       nextPageKey = cursor;
     } while (nextPageKey !== undefined);
 

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -32,7 +32,9 @@ import {
   IClientNotification,
   ICustomFieldList,
   ICustomer,
+  IGetWhatChangedResponse,
   INotification,
+  IWhatChangedOptions,
   ShareLevel,
   AcceptRejectAction,
 } from "./types/index.js";
@@ -541,6 +543,112 @@ export class PortfolioManager {
       },
     );
     return properties;
+  }
+
+  /**
+   * Drains a What's Changed endpoint and maps its entity links to IDs.
+   * Pagination links are transport details, so the facade follows their
+   * opaque cursor values rather than returning them to callers.
+   */
+  private async collectChangedIds(
+    resourceName: "property" | "property use" | "meter",
+    fetchPage: (
+      options: IWhatChangedOptions,
+    ) => Promise<IGetWhatChangedResponse>,
+  ): Promise<number[]> {
+    const ids: number[] = [];
+    let nextPageKey: string | number | undefined;
+
+    do {
+      const options: IWhatChangedOptions =
+        nextPageKey === undefined ? {} : { nextPageKey };
+      const response = await fetchPage(options);
+      if (response.response["@_status"] !== "Ok") {
+        throw new Error(
+          "Request Error, response: " + JSON.stringify(response, null, 2),
+        );
+      }
+      if (isIEmptyResponse(response.response)) {
+        nextPageKey = undefined;
+        continue;
+      }
+      if (!isIPopulatedResponse(response.response)) {
+        throw new Error(
+          `Unexpected ${resourceName} What's Changed response: ${JSON.stringify(response, null, 2)}`,
+        );
+      }
+
+      const links = response.response.links.link;
+      const entityLinks = links.filter(
+        (link) =>
+          link["@_linkDescription"].toLowerCase() !== "next page" &&
+          link["@_linkDescription"].toLowerCase() !== "previous page",
+      );
+      for (const link of entityLinks) {
+        const id = parseLinkId(link);
+        if (id === undefined) {
+          throw new Error(
+            `Invalid ${resourceName} id in What's Changed link: ${JSON.stringify(link)}`,
+          );
+        }
+        ids.push(id);
+      }
+
+      const nextLink = links.find(
+        (link) => link["@_linkDescription"].toLowerCase() === "next page",
+      );
+      if (!nextLink) {
+        nextPageKey = undefined;
+        continue;
+      }
+
+      const nextUrl = new URL(
+        nextLink["@_link"],
+        "https://portfoliomanager.energystar.gov",
+      );
+      const cursor = nextUrl.searchParams.get("nextPageKey");
+      if (!cursor) {
+        throw new Error(
+          `Invalid next page link for ${resourceName} What's Changed results: ${nextLink["@_link"]}`,
+        );
+      }
+      nextPageKey = cursor;
+    } while (nextPageKey !== undefined);
+
+    return ids;
+  }
+
+  /** Returns IDs for properties changed since date across all result pages. */
+  async getChangedPropertyIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]> {
+    const resolvedCustomerId = customerId ?? (await this.getAccountId());
+    return this.collectChangedIds("property", (options) =>
+      this.api.propertyGetWhatChangedGet(resolvedCustomerId, date, options),
+    );
+  }
+
+  /** Returns IDs for property uses changed since date across all result pages. */
+  async getChangedPropertyUseIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]> {
+    const resolvedCustomerId = customerId ?? (await this.getAccountId());
+    return this.collectChangedIds("property use", (options) =>
+      this.api.propertyUseGetWhatChangedGet(resolvedCustomerId, date, options),
+    );
+  }
+
+  /** Returns IDs for meters changed since date across all result pages. */
+  async getChangedMeterIds(
+    date: string,
+    customerId?: number,
+  ): Promise<number[]> {
+    const resolvedCustomerId = customerId ?? (await this.getAccountId());
+    return this.collectChangedIds("meter", (options) =>
+      this.api.meterGetWhatChangedGet(resolvedCustomerId, date, options),
+    );
   }
 
   async getPropertyMonthlyMetrics(

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -557,7 +557,7 @@ export class PortfolioManager {
     ) => Promise<IGetWhatChangedResponse>,
   ): Promise<number[]> {
     const ids: number[] = [];
-    let nextPageKey: string | number | undefined;
+    let nextPageKey: string | undefined;
 
     do {
       const options: IWhatChangedOptions =

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1371,7 +1371,7 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
       nextPageKey: "3000 / next",
     });
     await unitApi.meterGetWhatChangedGet(100, "2024-01-02", {
-      previousPageKey: 2000,
+      previousPageKey: "2000",
     });
 
     expect(getSpy).toHaveBeenNthCalledWith(

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -1363,6 +1363,69 @@ describe("PortfolioManagerApi (unit coverage paths)", () => {
     );
   });
 
+  it("What's Changed endpoint wrappers build date and cursor queries", async () => {
+    const getSpy = vi.spyOn(unitApi, "get").mockResolvedValue({} as never);
+
+    await unitApi.propertyGetWhatChangedGet(100, "2024-01-02");
+    await unitApi.propertyUseGetWhatChangedGet(100, "2024-01-02", {
+      nextPageKey: "3000 / next",
+    });
+    await unitApi.meterGetWhatChangedGet(100, "2024-01-02", {
+      previousPageKey: 2000,
+    });
+
+    expect(getSpy).toHaveBeenNthCalledWith(
+      1,
+      "customer/100/property/whatChanged?date=2024-01-02",
+    );
+    expect(getSpy).toHaveBeenNthCalledWith(
+      2,
+      "customer/100/propertyUse/whatChanged?date=2024-01-02&nextPageKey=3000+%2F+next",
+    );
+    expect(getSpy).toHaveBeenNthCalledWith(
+      3,
+      "customer/100/meter/whatChanged?date=2024-01-02&previousPageKey=2000",
+    );
+  });
+
+  it("What's Changed endpoint wrappers reject invalid query combinations", async () => {
+    await expect(
+      unitApi.propertyGetWhatChangedGet(100, "01/02/2024"),
+    ).rejects.toThrow("date must be a valid date formatted as YYYY-MM-DD");
+    await expect(
+      unitApi.meterGetWhatChangedGet(100, "2024-02-30"),
+    ).rejects.toThrow("date must be a valid date formatted as YYYY-MM-DD");
+    await expect(
+      unitApi.propertyUseGetWhatChangedGet(100, "2024-01-02", {
+        nextPageKey: "3000",
+        previousPageKey: "1000",
+      }),
+    ).rejects.toThrow(
+      "nextPageKey and previousPageKey cannot be used together",
+    );
+  });
+
+  it("What's Changed responses preserve link arrays for a single result", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        `<response status="Ok"><links><link id="86" httpMethod="GET" link="/property/86" linkDescription="This is the GET url for this Property." hint="Store"/></links></response>`,
+        { status: 200, statusText: "OK" },
+      ),
+    );
+
+    const result = await unitApi.propertyGetWhatChangedGet(100, "2024-01-02");
+
+    expect(fetchMock.mock.calls[0][0]).to.equal(
+      "https://example.test/customer/100/property/whatChanged?date=2024-01-02",
+    );
+    expect(result.response.links).not.to.be.a("string");
+    if (typeof result.response.links === "string") {
+      throw new Error("Expected a populated What's Changed response");
+    }
+    expect(result.response.links.link).to.have.length(1);
+    expect(result.response.links.link[0]["@_id"]).to.equal("86");
+  });
+
   it("propertyCreateSamplePropertiesPOST uses defaults and explicit args", async () => {
     const postSpy = vi.spyOn(unitApi, "post").mockResolvedValue({} as never);
 

--- a/src/PortfolioManagerApi.ts
+++ b/src/PortfolioManagerApi.ts
@@ -15,6 +15,7 @@ import {
   IGetPendingConnectionsResponse,
   IGetPendingMeterSharesResponse,
   IGetPendingPropertySharesResponse,
+  IGetWhatChangedResponse,
   IMeterConsumptionDataGetResponse,
   IMeterConsumptionDataPutResponse,
   IMeterIdentifierGetResponse,
@@ -36,6 +37,7 @@ import {
   IPropertyPropertyListGetResponse,
   IPropertyPropertyPostResponse,
   ISharingActionResponse,
+  IWhatChangedOptions,
   MeasurementSystem,
 } from "./types/index.js";
 import {
@@ -350,6 +352,77 @@ export class PortfolioManagerApi {
     return this.get<IPropertyPropertyListGetResponse>(
       `account/${accountId}/property/list`,
     );
+  }
+
+  private async getWhatChanged(
+    resource: "property" | "propertyUse" | "meter",
+    customerId: number,
+    date: string,
+    options: IWhatChangedOptions = {},
+  ): Promise<IGetWhatChangedResponse> {
+    const parsedDate = new Date(`${date}T00:00:00.000Z`);
+    if (
+      !/^\d{4}-\d{2}-\d{2}$/.test(date) ||
+      Number.isNaN(parsedDate.getTime()) ||
+      parsedDate.toISOString().slice(0, 10) !== date
+    ) {
+      throw new TypeError("date must be a valid date formatted as YYYY-MM-DD");
+    }
+    if (
+      options.nextPageKey !== undefined &&
+      options.previousPageKey !== undefined
+    ) {
+      throw new TypeError(
+        "nextPageKey and previousPageKey cannot be used together",
+      );
+    }
+
+    const query = new URLSearchParams({ date });
+    if (options.nextPageKey !== undefined) {
+      query.set("nextPageKey", String(options.nextPageKey));
+    }
+    if (options.previousPageKey !== undefined) {
+      query.set("previousPageKey", String(options.previousPageKey));
+    }
+    return this.get<IGetWhatChangedResponse>(
+      `customer/${customerId}/${resource}/whatChanged?${query.toString()}`,
+    );
+  }
+
+  /**
+   * Returns properties changed since the supplied date.
+   * @see https://portfoliomanager.energystar.gov/webservices/home/api/property/getWhatChanged/get
+   */
+  async propertyGetWhatChangedGet(
+    customerId: number,
+    date: string,
+    options: IWhatChangedOptions = {},
+  ): Promise<IGetWhatChangedResponse> {
+    return this.getWhatChanged("property", customerId, date, options);
+  }
+
+  /**
+   * Returns property uses changed since the supplied date.
+   * @see https://portfoliomanager.energystar.gov/webservices/home/api/propertyUse/getWhatChanged/get
+   */
+  async propertyUseGetWhatChangedGet(
+    customerId: number,
+    date: string,
+    options: IWhatChangedOptions = {},
+  ): Promise<IGetWhatChangedResponse> {
+    return this.getWhatChanged("propertyUse", customerId, date, options);
+  }
+
+  /**
+   * Returns meters changed since the supplied date.
+   * @see https://portfoliomanager.energystar.gov/webservices/home/api/meter/getWhatChanged/get
+   */
+  async meterGetWhatChangedGet(
+    customerId: number,
+    date: string,
+    options: IWhatChangedOptions = {},
+  ): Promise<IGetWhatChangedResponse> {
+    return this.getWhatChanged("meter", customerId, date, options);
   }
 
   // https://portfoliomanager.energystar.gov/webservices/home/api/meter/consumptionData/post

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -4,3 +4,4 @@ export * from "./MeasurementSystem.js";
 export * from "./meter.js";
 export * from "./METRICS.js";
 export * from "./property.js";
+export * from "./whatChanged.js";

--- a/src/types/api/whatChanged.ts
+++ b/src/types/api/whatChanged.ts
@@ -1,0 +1,14 @@
+import { IResponse } from "../xml/index.js";
+import { IParsedXml } from "./IParsedXML.js";
+
+/** Cursor values returned by Portfolio Manager are opaque, not page numbers. */
+export type WhatChangedPageKey = string | number;
+
+export interface IWhatChangedOptions {
+  nextPageKey?: WhatChangedPageKey;
+  previousPageKey?: WhatChangedPageKey;
+}
+
+export interface IGetWhatChangedResponse extends IParsedXml {
+  response: IResponse;
+}

--- a/src/types/api/whatChanged.ts
+++ b/src/types/api/whatChanged.ts
@@ -2,7 +2,7 @@ import { IResponse } from "../xml/index.js";
 import { IParsedXml } from "./IParsedXML.js";
 
 /** Cursor values returned by Portfolio Manager are opaque, not page numbers. */
-export type WhatChangedPageKey = string | number;
+export type WhatChangedPageKey = string;
 
 export interface IWhatChangedOptions {
   nextPageKey?: WhatChangedPageKey;


### PR DESCRIPTION
## Summary
- add typed property, property-use, and meter What's Changed API methods
- add facade methods that map all paginated entity links to ID arrays
- default facade calls to the current account with an optional customer override
- validate YYYY-MM-DD dates, cursor directions, entity IDs, and pagination links
- preserve opaque cursor values and stable response link arrays
- document API and facade usage

## Validation
- npm run typecheck
- npm run build
- npm run lint
- npm run format:check
- focused What's Changed API and facade tests
- npm test -- --exclude src/PortfolioManager.spec.ts (123 passed, 13 skipped)
- node ./dist/cli.js --help

The credential-backed integration tests in src/PortfolioManager.spec.ts were not run because PM_USERNAME and PM_PASSWORD are unavailable. Its new synthetic facade tests pass independently with non-network placeholder credentials.

Fixes #66