### PR TITLE
fix: enforce coverage before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,12 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: node ./dist/cli.js --help # Run the CLI to ensure it works, we had some test releases where this was broken during the esm migration
-      - run: npm test
+      - name: Run tests with coverage
+        if: matrix.node-version == 'lts/*'
+        run: npm run test:coverage
+      - name: Run tests
+        if: matrix.node-version != 'lts/*'
+        run: npm test
 
   release:
     needs: test
@@ -53,11 +58,6 @@ jobs:
       issues: write # comment on released issues
       pull-requests: write # comment on released PRs
       id-token: write # npm trusted publishing via OIDC
-    env:
-      PM_USERNAME: ${{ secrets.PM_USERNAME }}
-      PM_PASSWORD: ${{ secrets.PM_PASSWORD }}
-      PM_USERNAME2: ${{ secrets.PM_USERNAME2 }}
-      PM_PASSWORD2: ${{ secrets.PM_PASSWORD2 }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -73,7 +73,6 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: node ./dist/cli.js --help # Run the CLI to ensure it works, we had some test releases where this was broken during the esm migration
-      - run: npm run test:coverage # Run tests with coverage to ensure we fail if there are uncovered lines (e.g. due to a new file missing tests)
       - name: Semantic Release with Trusted Publishing via OIDC
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -737,6 +737,56 @@ describe("PortfolioManager (minimal synthetic edge cases)", () => {
     );
   });
 
+  it("getChangedPropertyUseIds and getChangedMeterIds default to the current account", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+
+    vi.mocked(api.accountAccountGet).mockResolvedValueOnce({
+      account: { id: 77 },
+    } as never);
+    vi.mocked(api.propertyUseGetWhatChangedGet).mockResolvedValueOnce({
+      response: { "@_status": "Ok", links: "" },
+    } as never);
+    vi.mocked(api.meterGetWhatChangedGet).mockResolvedValueOnce({
+      response: { "@_status": "Ok", links: "" },
+    } as never);
+
+    await expect(pm.getChangedPropertyUseIds("2024-01-01")).resolves.toEqual(
+      [],
+    );
+    await expect(pm.getChangedMeterIds("2024-01-01")).resolves.toEqual([]);
+    expect(api.accountAccountGet).toHaveBeenCalledTimes(1);
+    expect(api.propertyUseGetWhatChangedGet).toHaveBeenCalledWith(
+      77,
+      "2024-01-01",
+      {},
+    );
+    expect(api.meterGetWhatChangedGet).toHaveBeenCalledWith(
+      77,
+      "2024-01-01",
+      {},
+    );
+  });
+
+  it("getChanged ID collection rejects failed and malformed responses", async () => {
+    const api = createExtendedMockApi();
+    const pm = new PortfolioManager(api);
+
+    vi.mocked(api.propertyGetWhatChangedGet).mockResolvedValueOnce({
+      response: { "@_status": "Error", links: "" },
+    } as never);
+    vi.mocked(api.propertyUseGetWhatChangedGet).mockResolvedValueOnce({
+      response: { "@_status": "Ok", links: { link: "not-an-array" } },
+    } as never);
+
+    await expect(pm.getChangedPropertyIds("2024-01-01", 88)).rejects.toThrow(
+      "Request Error, response",
+    );
+    await expect(pm.getChangedPropertyUseIds("2024-01-01", 88)).rejects.toThrow(
+      "Unexpected property use What's Changed response",
+    );
+  });
+
   it("getChanged ID collection rejects malformed entity and pagination links", async () => {
     const api = createExtendedMockApi();
     const pm = new PortfolioManager(api);

--- a/src/PortfolioManagerApi.spec.ts
+++ b/src/PortfolioManagerApi.spec.ts
@@ -29,6 +29,7 @@ import {
   ILink,
   IMeter,
   isIEmptyResponse,
+  isIPropertyMetricValueNull,
   isIPropertyMonthlyMetric,
   isIPopulatedResponse,
   isIPropertyAnnualMetric,
@@ -808,6 +809,11 @@ describeIntegration("PortfolioManagerApi (integration)", () => {
 });
 
 describe("PortfolioManagerApi (unit coverage paths)", () => {
+  it("distinguishes parsed xsi:nil markers from missing metric values", () => {
+    expect(isIPropertyMetricValueNull({ "@_xsi:nil": true })).to.equal(true);
+    expect(isIPropertyMetricValueNull(undefined as never)).to.equal(false);
+  });
+
   const unitApi = new PortfolioManagerApi(
     "https://example.test/",
     "test-user",


### PR DESCRIPTION
## Summary

- run the 100% coverage gate in the existing LTS test matrix entry
- keep ordinary tests on Node 20, 22, and latest without adding another suite execution
- remove the duplicate late coverage run and unused Portfolio Manager secrets from the release job
- add deterministic regression coverage for What's Changed response and account-resolution paths
- cover the pre-existing defensive annual-metric null guard

## Root cause

The regular test matrix ran `npm test`, while `npm run test:coverage` ran only inside the release job on `main` and `next`. PR #67 therefore passed its branch checks despite adding uncovered paths, and the coverage failure surfaced only after merge. The preceding `next` release was already failing on a data-dependent `PropertyMetrics.ts` branch.

Failed run: https://github.com/dopry/portfolio-manager/actions/runs/30937513230/job/92088201905

## Impact

Coverage regressions now fail the LTS matrix check before release. The suite still runs four times across the supported Node matrix instead of increasing to five executions, and API access remains serialized by the existing matrix limit.

## Validation

- 124 credential-free tests passed
- 43 synthetic PortfolioManager tests passed
- 27 PortfolioManagerApi unit coverage tests passed
- targeted V8 coverage recorded execution for all four newly uncovered PortfolioManager lines
- PropertyMetrics branch coverage reached 100% in the targeted run
- `npm run typecheck`
- `npm run build`
- scoped ESLint and Prettier checks
