### PR TITLE
Stabilize scheduled E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       PM_USERNAME: ${{ secrets.PM_USERNAME }}
       PM_PASSWORD: ${{ secrets.PM_PASSWORD }}
@@ -31,12 +32,42 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: npm run typecheck:e2e
-      - run: npm run test:e2e
+      - name: Run E2E tests
+        id: e2e
+        shell: bash
+        run: |
+          run_e2e() {
+            local attempt="$1"
+            echo "::group::E2E attempt ${attempt}/2"
+            export E2E_TRACE_DIR="test-results/e2e/attempt-${attempt}"
+            local test_exit=0
+            npm run test:e2e || test_exit=$?
+            echo "::endgroup::"
+            return "$test_exit"
+          }
+
+          if run_e2e 1; then
+            exit 0
+          fi
+
+          # Every suite invocation runs peer-scoped cleanup in beforeAll and
+          # best-effort cleanup in afterAll. Re-invoking the suite therefore
+          # re-establishes its baseline without the destructive account-wide
+          # wipe:test-environment command.
+          echo "retried=true" >> "${GITHUB_OUTPUT:-/dev/null}"
+          {
+            echo "## E2E retry"
+            echo "Attempt 1 failed; the suite was retried after a 30-second backoff."
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          echo "::warning::E2E attempt 1 failed; retrying the clean suite in 30 seconds"
+          sleep 30
+
+          run_e2e 2
       # Tracing starts after login (EspmWebUi), so no credentials appear in
       # these artifacts; residual content is post-auth pages/session data for
       # throwaway test-environment accounts.
       - name: Upload Playwright traces
-        if: failure()
+        if: failure() || steps.e2e.outputs.retried == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-traces

--- a/test/e2e/connectionSharing.e2e.spec.ts
+++ b/test/e2e/connectionSharing.e2e.spec.ts
@@ -1,5 +1,4 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { PortfolioManagerApiError } from "../../src/PortfolioManagerApi.js";
 import { EspmWebUi } from "./EspmWebUi.js";
 import {
   createClient,
@@ -8,6 +7,7 @@ import {
   ensurePeerFixtures,
   getE2eConfig,
   waitFor,
+  waitForNoAccess,
   E2E_PROPERTY_NAME,
   IE2eClient,
 } from "./support.js";
@@ -68,22 +68,6 @@ describe("Connection & Sharing (e2e)", () => {
       // Shared test environment: never mask a test failure with cleanup noise.
     }
   });
-
-  /**
-   * Asserts the call fails specifically because access is revoked (ESPM
-   * answers 403 Access Denied, occasionally 404), so transient failures
-   * (5xx, network) don't masquerade as successful revocation.
-   */
-  async function expectNoAccess(promise: Promise<unknown>): Promise<void> {
-    try {
-      await promise;
-    } catch (error) {
-      expect(error).toBeInstanceOf(PortfolioManagerApiError);
-      expect([403, 404]).toContain((error as PortfolioManagerApiError).status);
-      return;
-    }
-    throw new Error("Expected access to be revoked, but the call succeeded");
-  }
 
   function step(name: string, fn: () => Promise<void>): void {
     it(name, async () => {
@@ -176,7 +160,9 @@ describe("Connection & Sharing (e2e)", () => {
     await provider.pm.unshareMeter(fixture.meterId, "e2e unshare");
     await provider.pm.unshareProperty(fixture.propertyId, "e2e unshare");
 
-    await expectNoAccess(provider.pm.getProperty(fixture.propertyId));
+    await waitForNoAccess(() => provider.pm.getProperty(fixture.propertyId), {
+      label: "property access to be revoked",
+    });
 
     // Seed a second share and exercise the reject path.
     await ui.setupDataExchangeShare({
@@ -198,7 +184,9 @@ describe("Connection & Sharing (e2e)", () => {
       }
     }
 
-    await expectNoAccess(provider.pm.getProperty(fixture.propertyId));
+    await waitForNoAccess(() => provider.pm.getProperty(fixture.propertyId), {
+      label: "property access to be revoked",
+    });
   });
 
   step("disconnect returns the accounts to baseline", async () => {

--- a/test/e2e/support.ts
+++ b/test/e2e/support.ts
@@ -94,6 +94,41 @@ export async function waitFor<T>(
   }
 }
 
+function isAccessRevokedError(
+  error: unknown,
+): error is PortfolioManagerApiError {
+  return (
+    error instanceof PortfolioManagerApiError &&
+    (error.status === 403 || error.status === 404)
+  );
+}
+
+/**
+ * Waits for access revocation to propagate. ESPM answers 403 Access Denied
+ * (occasionally 404) once complete, but accepted shares can remain readable
+ * briefly after an unshare. Unexpected failures (5xx, network, auth) still
+ * fail immediately rather than masquerading as successful revocation.
+ */
+export async function waitForNoAccess(
+  probe: () => Promise<unknown>,
+  options: { timeoutMs?: number; intervalMs?: number; label?: string } = {},
+): Promise<void> {
+  await waitFor(
+    async () => {
+      try {
+        await probe();
+        return undefined;
+      } catch (error) {
+        if (isAccessRevokedError(error)) {
+          return true;
+        }
+        throw error;
+      }
+    },
+    { ...options, label: options.label ?? "access to be revoked" },
+  );
+}
+
 /**
  * Ensures the peer account owns the fixture property with one meter, and
  * returns their ids. Runs against the web services API with peer credentials.
@@ -162,10 +197,7 @@ export async function disconnectIfConnected(
       note: "e2e cleanup",
     });
   } catch (error) {
-    if (
-      error instanceof PortfolioManagerApiError &&
-      (error.status === 403 || error.status === 404)
-    ) {
+    if (isAccessRevokedError(error)) {
       return; // Not connected — already at baseline.
     }
     throw error;

--- a/test/e2e/support.unit.spec.ts
+++ b/test/e2e/support.unit.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { PortfolioManagerApiError } from "../../src/PortfolioManagerApi.js";
+import { waitForNoAccess } from "./support.js";
+
+describe("waitForNoAccess", () => {
+  it("polls until ESPM reports that access is revoked", async () => {
+    const probe = vi
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValueOnce({ id: 123 })
+      .mockResolvedValueOnce({ id: 123 })
+      .mockRejectedValueOnce(
+        new PortfolioManagerApiError(403, "Access Denied"),
+      );
+
+    await waitForNoAccess(probe, { timeoutMs: 5000, intervalMs: 0 });
+
+    expect(probe).toHaveBeenCalledTimes(3);
+  });
+
+  it("also accepts ESPM's not-found response as revoked access", async () => {
+    const probe = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(new PortfolioManagerApiError(404, "Not Found"));
+
+    await waitForNoAccess(probe, { timeoutMs: 5000, intervalMs: 0 });
+
+    expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("propagates unexpected API failures without retrying", async () => {
+    const error = new PortfolioManagerApiError(500, "Internal Server Error");
+    const probe = vi.fn<() => Promise<unknown>>().mockRejectedValue(error);
+
+    await expect(
+      waitForNoAccess(probe, { timeoutMs: 5000, intervalMs: 0 }),
+    ).rejects.toBe(error);
+    expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("propagates non-API failures without retrying", async () => {
+    const error = new TypeError("fetch failed");
+    const probe = vi.fn<() => Promise<unknown>>().mockRejectedValue(error);
+
+    await expect(
+      waitForNoAccess(probe, { timeoutMs: 5000, intervalMs: 0 }),
+    ).rejects.toBe(error);
+    expect(probe).toHaveBeenCalledOnce();
+  });
+
+  it("reports when access remains available through the deadline", async () => {
+    const probe = vi
+      .fn<() => Promise<unknown>>()
+      .mockResolvedValue({ id: 123 });
+
+    await expect(
+      waitForNoAccess(probe, {
+        timeoutMs: 0,
+        intervalMs: 0,
+        label: "property access to be revoked",
+      }),
+    ).rejects.toThrow(
+      "Timed out after 0ms waiting for property access to be revoked",
+    );
+    expect(probe).toHaveBeenCalledOnce();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
-    include: ["src/**/*.spec.ts"],
+    include: ["src/**/*.spec.ts", "test/**/*.unit.spec.ts"],
     testTimeout: 60000,
     hookTimeout: 60000,
     fileParallelism: false,


### PR DESCRIPTION
## Summary

- poll until ESPM access revocation propagates instead of requiring an immediate 403/404
- retry the complete stateful E2E suite once after peer-scoped cleanup and a 30-second backoff
- preserve per-attempt Playwright traces and surface retries in the workflow summary
- add regression coverage for delayed revocation and unexpected 5xx responses

## Failure evidence

- transient ESPM HTTP 500 during share setup, handled by the suite-level retry: https://github.com/dopry/portfolio-manager/actions/runs/30886753561
- delayed access revocation, handled by polling for 403/404: https://github.com/dopry/portfolio-manager/actions/runs/30689060525

## Testing

- `npm exec -- eslint . --ignore-pattern '.claude/**'`
- `npm exec -- prettier --check .github/workflows/e2e.yml test/e2e/connectionSharing.e2e.spec.ts test/e2e/support.ts test/e2e/support.unit.spec.ts vitest.config.ts`
- `npm run typecheck`
- `npm run typecheck:e2e`
- `npm test -- test/e2e/support.unit.spec.ts` (5 passed)
- `npm test -- --exclude src/PortfolioManager.spec.ts` (129 passed, 13 skipped; excluded suite requires live credentials)