### PR TITLE
feat: add core property import and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,41 @@ npx portfolio-manager notifications list --no-clear --indent 2
 Run `npx portfolio-manager <command> --help` for the complete options for a
 command.
 
+### Portable property bundles (core preview)
+
+Export one or more properties to deterministic, versioned JSON:
+
+```bash
+npx portfolio-manager property export --output property.json 123
+npx portfolio-manager property export --all --output portfolio.json
+```
+
+Existing files are not overwritten unless `--force` is supplied. Use stdout
+instead of a file by omitting `--output`.
+
+Validate a bundle without creating anything, then import it into the
+authenticated account or a connected customer account:
+
+```bash
+npx portfolio-manager property import property.json --dry-run
+npx portfolio-manager property import property.json --account-id 456
+```
+
+This first bundle capability carries core property fields only. It deliberately
+omits Portfolio Manager IDs, audit/access fields, property uses, meters,
+consumption, associations, and sharing. Those child-resource capabilities will
+be added without changing the v1 core-property shape.
+
+Bundles identify the v1 schema with the stable
+`urn:portfolio-manager:property-bundle:v1` URN. The schema ships with the
+package as `PROPERTY_BUNDLE_SCHEMA_DOCUMENT` and through the
+`portfolio-manager/schemas/property-bundle-v1.schema.json` export, so validation
+does not depend on a moving GitHub branch.
+
+Property bundles can contain sensitive names, addresses, identifiers, notes,
+costs, and consumption as capabilities are added. Store production exports as
+securely as the source account data.
+
 ## Local Development Workflow
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.3.5",
         "@vitest/coverage-v8": "^4.0.18",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "eslint": "^10.6.0",
         "eslint-config-prettier": "^10.1.8",
         "playwright": "^1.61.1",
@@ -2155,20 +2157,38 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -3048,6 +3068,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3060,6 +3097,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.2.0",
@@ -3226,6 +3270,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.1",
@@ -4007,9 +4068,9 @@
       "dev": true
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -7057,6 +7118,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -9719,15 +9790,24 @@
       }
     },
     "ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "ansi-escapes": {
@@ -10295,10 +10375,28 @@
         "optionator": "^0.9.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.15.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+          "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
           "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         }
       }
@@ -10438,6 +10536,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true
     },
     "fast-xml-builder": {
@@ -10963,9 +11067,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
@@ -12960,6 +13064,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "resolve-from": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
       "types": "./dist/cli/index.d.ts",
       "import": "./dist/cli/index.js"
     },
+    "./schemas/property-bundle-v1.schema.json": "./dist/schemas/property-bundle-v1.schema.json",
     "./package.json": "./package.json"
   },
   "sideEffects": false,
@@ -58,6 +59,8 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.3.5",
     "@vitest/coverage-v8": "^4.0.18",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",
     "playwright": "^1.61.1",

--- a/src/PortfolioManager.propertyBundle.spec.ts
+++ b/src/PortfolioManager.propertyBundle.spec.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it, vi } from "vitest";
+import { mockIProperty } from "./Mocks.js";
+import { PortfolioManager } from "./PortfolioManager.js";
+import type { PortfolioManagerApi } from "./PortfolioManagerApi.js";
+import {
+  PROPERTY_BUNDLE_FORMAT,
+  PROPERTY_BUNDLE_SCHEMA,
+  PROPERTY_BUNDLE_VERSION,
+  type IPropertyBundleV1,
+} from "./types/index.js";
+
+function createClient(): PortfolioManager {
+  return new PortfolioManager({} as PortfolioManagerApi, { concurrency: 2 });
+}
+
+function bundle(names = ["One"]): IPropertyBundleV1 {
+  return {
+    $schema: PROPERTY_BUNDLE_SCHEMA,
+    format: PROPERTY_BUNDLE_FORMAT,
+    formatVersion: PROPERTY_BUNDLE_VERSION,
+    capabilities: ["property"],
+    properties: names.map((name, index) => ({
+      ref: `property:${index + 1}`,
+      property: { ...mockIProperty(), name },
+    })),
+  };
+}
+
+describe("PortfolioManager property bundle facade", () => {
+  it("creates a property in an explicitly selected account", async () => {
+    const property = mockIProperty();
+    const post = vi.fn().mockResolvedValue({
+      response: { "@_status": "Ok", id: 100, links: { link: [] } },
+    });
+    const client = new PortfolioManager({
+      propertyPropertyPost: post,
+    } as unknown as PortfolioManagerApi);
+    vi.spyOn(client, "getProperty").mockResolvedValue({
+      ...property,
+      id: 100,
+    });
+
+    await expect(client.createProperty(property, 55)).resolves.toMatchObject({
+      id: 100,
+    });
+    expect(post).toHaveBeenCalledWith(property, 55);
+  });
+
+  it("exports properties in stable id order without response metadata", async () => {
+    const client = createClient();
+    vi.spyOn(client, "getProperty").mockImplementation(async (id) => ({
+      ...mockIProperty(),
+      id,
+      name: `Property ${id}`,
+      accessLevel: "Full",
+      audit: { createdBy: "user" },
+    }));
+
+    const result = await client.exportProperties([20, 10]);
+
+    expect(client.getProperty).toHaveBeenCalledWith(10);
+    expect(client.getProperty).toHaveBeenCalledWith(20);
+    expect(result.properties.map((entry) => entry.ref)).toEqual([
+      "property:1",
+      "property:2",
+    ]);
+    expect(result.properties.map((entry) => entry.property.name)).toEqual([
+      "Property 10",
+      "Property 20",
+    ]);
+    expect(result.properties[0].property).not.toHaveProperty("id");
+    expect(result.properties[0].property).not.toHaveProperty("audit");
+    expect(result.properties[0].property).not.toHaveProperty("accessLevel");
+  });
+
+  it("exports one property and reports progress", async () => {
+    const client = createClient();
+    vi.spyOn(client, "getProperty").mockResolvedValue({
+      ...mockIProperty(),
+      id: 10,
+    });
+    const onProgress = vi.fn();
+
+    await expect(
+      client.exportProperty(10, { onProgress }),
+    ).resolves.toMatchObject({
+      properties: [{ ref: "property:1" }],
+    });
+    expect(onProgress).toHaveBeenCalledWith({
+      operation: "export",
+      propertyRef: "property:1",
+      completed: 1,
+      total: 1,
+    });
+  });
+
+  it("rejects invalid property id selections", async () => {
+    const client = createClient();
+
+    await expect(client.exportProperties([])).rejects.toThrow(
+      "At least one property id is required",
+    );
+    await expect(client.exportProperties([0])).rejects.toThrow(
+      "positive integers",
+    );
+    await expect(client.exportProperties([1.5])).rejects.toThrow(
+      "positive integers",
+    );
+    await expect(client.exportProperties([1, 1])).rejects.toThrow(
+      "must not contain duplicates",
+    );
+  });
+
+  it("validates a dry run without making API calls", async () => {
+    const client = createClient();
+    const create = vi.spyOn(client, "createProperty");
+
+    await expect(
+      client.importProperties(bundle(["One", "Two"]), { dryRun: true }),
+    ).resolves.toEqual({
+      status: "dry-run",
+      properties: [
+        { ref: "property:1", status: "planned" },
+        { ref: "property:2", status: "planned" },
+      ],
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("preflights target account ids and modified property names", async () => {
+    const client = createClient();
+    const create = vi.spyOn(client, "createProperty");
+
+    await expect(
+      client.importProperties(bundle(), { accountId: 0, dryRun: true }),
+    ).rejects.toThrow("Target account id must be a positive integer");
+    await expect(
+      client.importProperties(bundle(), {
+        dryRun: true,
+        namePrefix: "x".repeat(80),
+      }),
+    ).rejects.toThrow("must contain 1-80 characters");
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("imports into an explicit account and modifies names only when asked", async () => {
+    const client = createClient();
+    const create = vi
+      .spyOn(client, "createProperty")
+      .mockResolvedValue({ ...mockIProperty(), id: 100 } as never);
+
+    await expect(
+      client.importProperties(bundle(), {
+        accountId: 55,
+        namePrefix: "Copy of ",
+        nameSuffix: " (fixture)",
+      }),
+    ).resolves.toEqual({
+      status: "complete",
+      properties: [{ ref: "property:1", status: "created", id: 100 }],
+    });
+    expect(create).toHaveBeenCalledWith(
+      { ...mockIProperty(), name: "Copy of One (fixture)" },
+      55,
+    );
+  });
+
+  it("converts portable floor-area dates back to API dates", async () => {
+    const client = createClient();
+    const create = vi
+      .spyOn(client, "createProperty")
+      .mockResolvedValue({ ...mockIProperty(), id: 100 } as never);
+    const value = bundle();
+    value.properties[0].property.grossFloorArea.currentAsOf = "2026-08-05";
+
+    await client.importProperties(value);
+
+    expect(create).toHaveBeenCalledWith(
+      {
+        ...mockIProperty(),
+        name: "One",
+        grossFloorArea: {
+          ...mockIProperty().grossFloorArea,
+          currentAsOf: new Date("2026-08-05T00:00:00Z"),
+        },
+      },
+      undefined,
+    );
+  });
+
+  it("reports import and cleanup progress", async () => {
+    const client = createClient();
+    vi.spyOn(client, "createProperty")
+      .mockResolvedValueOnce({ ...mockIProperty(), id: 100 } as never)
+      .mockRejectedValueOnce("create failed");
+    vi.spyOn(client, "deleteProperty").mockResolvedValue(true);
+    const onProgress = vi.fn();
+
+    await expect(
+      client.importProperties(bundle(["One", "Two"]), { onProgress }),
+    ).resolves.toMatchObject({ status: "failed", error: "create failed" });
+    expect(onProgress).toHaveBeenNthCalledWith(1, {
+      operation: "import",
+      propertyRef: "property:1",
+      completed: 1,
+      total: 2,
+    });
+    expect(onProgress).toHaveBeenNthCalledWith(2, {
+      operation: "cleanup",
+      propertyRef: "property:1",
+      completed: 1,
+      total: 1,
+    });
+  });
+
+  it("rolls back properties from the current import after a failure", async () => {
+    const client = createClient();
+    vi.spyOn(client, "createProperty")
+      .mockResolvedValueOnce({ ...mockIProperty(), id: 100 } as never)
+      .mockRejectedValueOnce(new Error("create failed"));
+    const remove = vi.spyOn(client, "deleteProperty").mockResolvedValue(true);
+
+    await expect(
+      client.importProperties(bundle(["One", "Two"])),
+    ).resolves.toEqual({
+      status: "failed",
+      error: "create failed",
+      properties: [
+        { ref: "property:1", status: "rolled-back", id: 100 },
+        { ref: "property:2", status: "failed", error: "create failed" },
+      ],
+    });
+    expect(remove).toHaveBeenCalledWith(100);
+  });
+
+  it("can keep successfully created properties after a failure", async () => {
+    const client = createClient();
+    vi.spyOn(client, "createProperty")
+      .mockResolvedValueOnce({ ...mockIProperty(), id: 100 } as never)
+      .mockRejectedValueOnce(new Error("create failed"));
+    const remove = vi.spyOn(client, "deleteProperty");
+
+    const result = await client.importProperties(bundle(["One", "Two"]), {
+      keepPartial: true,
+    });
+
+    expect(result.properties[0]).toEqual({
+      ref: "property:1",
+      status: "created",
+      id: 100,
+    });
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it("reports cleanup failures without hiding the import error", async () => {
+    const client = createClient();
+    vi.spyOn(client, "createProperty")
+      .mockResolvedValueOnce({ ...mockIProperty(), id: 100 } as never)
+      .mockResolvedValueOnce({ ...mockIProperty(), id: 200 } as never)
+      .mockRejectedValueOnce(new Error("create failed"));
+    vi.spyOn(client, "deleteProperty")
+      .mockRejectedValueOnce(new Error("cleanup error"))
+      .mockRejectedValueOnce("cleanup string");
+
+    await expect(
+      client.importProperties(bundle(["One", "Two", "Three"])),
+    ).resolves.toEqual({
+      status: "failed",
+      error: "create failed",
+      properties: [
+        {
+          ref: "property:1",
+          status: "cleanup-failed",
+          id: 100,
+          error: "cleanup string",
+        },
+        {
+          ref: "property:2",
+          status: "cleanup-failed",
+          id: 200,
+          error: "cleanup error",
+        },
+        { ref: "property:3", status: "failed", error: "create failed" },
+      ],
+    });
+  });
+});

--- a/src/PortfolioManager.spec.ts
+++ b/src/PortfolioManager.spec.ts
@@ -188,6 +188,43 @@ describe("PortfolioManager (integration)", () => {
     ).to.equal(false);
   }, 90000);
 
+  it("exports and imports a property bundle in the wstest environment", async () => {
+    const source = await pm.createProperty({
+      ...mockIProperty(),
+      name: withRunId("PM Bundle Source"),
+    });
+    createdPropertyIds.push(source.id);
+
+    const bundle = await pm.exportProperty(source.id);
+    expect(bundle.properties).to.have.length(1);
+    expect(bundle.properties[0].property.name).to.equal(source.name);
+    expect(bundle.properties[0].property).not.to.have.property("id");
+    expect(bundle.properties[0].property).not.to.have.property("audit");
+
+    const result = await pm.importProperties(bundle, {
+      namePrefix: "Imported ",
+    });
+    expect(result.status, JSON.stringify(result)).to.equal("complete");
+    const importedResult = result.properties[0];
+    expect(importedResult.status, JSON.stringify(result)).to.equal("created");
+    if (importedResult.id === undefined) {
+      throw new Error(
+        `Expected imported property id: ${JSON.stringify(result)}`,
+      );
+    }
+    createdPropertyIds.push(importedResult.id);
+
+    const imported = await pm.getProperty(importedResult.id);
+    expect(imported.name).to.equal(`Imported ${source.name}`);
+    expect(imported.primaryFunction).to.equal(source.primaryFunction);
+    expect(imported.grossFloorArea.value).to.equal(source.grossFloorArea.value);
+
+    expect(await pm.deleteProperty(importedResult.id)).to.equal(true);
+    untrackId(createdPropertyIds, importedResult.id);
+    expect(await pm.deleteProperty(source.id)).to.equal(true);
+    untrackId(createdPropertyIds, source.id);
+  }, 120000);
+
   it("createMeter + getMeterLinks + getMeter", async () => {
     const propertyId = testPropertyIds[0];
 

--- a/src/PortfolioManager.ts
+++ b/src/PortfolioManager.ts
@@ -5,6 +5,10 @@ import {
 import { mapWithConcurrency } from "./functions/mapWithConcurrency.js";
 import { parseLinkId } from "./functions/parseLinkId.js";
 import {
+  sanitizePropertyForBundle,
+  validatePropertyBundle,
+} from "./PropertyBundle.js";
+import {
   IAccount,
   IAdditionalIdentifier,
   IClientConsumption,
@@ -37,6 +41,14 @@ import {
   IWhatChangedOptions,
   ShareLevel,
   AcceptRejectAction,
+  IExportPropertiesOptions,
+  IImportPropertiesOptions,
+  IImportPropertiesResult,
+  IImportPropertyResult,
+  IPropertyBundleV1,
+  PROPERTY_BUNDLE_FORMAT,
+  PROPERTY_BUNDLE_SCHEMA,
+  PROPERTY_BUNDLE_VERSION,
 } from "./types/index.js";
 
 /**
@@ -473,9 +485,15 @@ export class PortfolioManager {
     );
   }
 
-  async createProperty(property: Omit<IProperty, "id">): Promise<IProperty> {
-    const account = await this.getAccount();
-    const response = await this.api.propertyPropertyPost(property, account.id);
+  async createProperty(
+    property: Omit<IProperty, "id">,
+    accountId?: number,
+  ): Promise<IProperty> {
+    const targetAccountId = accountId ?? (await this.getAccountId());
+    const response = await this.api.propertyPropertyPost(
+      property,
+      targetAccountId,
+    );
     if (isIPopulatedResponse(response.response)) {
       const propertyId = response.response.id;
       return await this.getProperty(propertyId);
@@ -543,6 +561,167 @@ export class PortfolioManager {
       },
     );
     return properties;
+  }
+
+  async exportProperty(
+    propertyId: number,
+    options: IExportPropertiesOptions = {},
+  ): Promise<IPropertyBundleV1> {
+    return this.exportProperties([propertyId], options);
+  }
+
+  async exportProperties(
+    propertyIds: number[],
+    options: IExportPropertiesOptions = {},
+  ): Promise<IPropertyBundleV1> {
+    if (propertyIds.length === 0) {
+      throw new TypeError("At least one property id is required");
+    }
+    if (
+      propertyIds.some(
+        (propertyId) => !Number.isInteger(propertyId) || propertyId < 1,
+      )
+    ) {
+      throw new TypeError("Property ids must be positive integers");
+    }
+    if (new Set(propertyIds).size !== propertyIds.length) {
+      throw new TypeError("Property ids must not contain duplicates");
+    }
+
+    const sortedIds = [...propertyIds].sort((left, right) => left - right);
+    let completed = 0;
+    const properties = await mapWithConcurrency(
+      sortedIds,
+      this.concurrency,
+      async (propertyId, index) => {
+        const property = await this.getProperty(propertyId);
+        completed++;
+        const ref = `property:${index + 1}`;
+        options.onProgress?.({
+          operation: "export",
+          propertyRef: ref,
+          completed,
+          total: sortedIds.length,
+        });
+        return {
+          ref,
+          property: sanitizePropertyForBundle(property),
+        };
+      },
+    );
+
+    return {
+      $schema: PROPERTY_BUNDLE_SCHEMA,
+      format: PROPERTY_BUNDLE_FORMAT,
+      formatVersion: PROPERTY_BUNDLE_VERSION,
+      capabilities: ["property"],
+      properties,
+    };
+  }
+
+  async importProperties(
+    bundle: unknown,
+    options: IImportPropertiesOptions = {},
+  ): Promise<IImportPropertiesResult> {
+    validatePropertyBundle(bundle);
+    if (
+      options.accountId !== undefined &&
+      (!Number.isInteger(options.accountId) || options.accountId < 1)
+    ) {
+      throw new TypeError("Target account id must be a positive integer");
+    }
+    const imports = bundle.properties.map((entry) => {
+      const { currentAsOf, ...grossFloorArea } = entry.property.grossFloorArea;
+      return {
+        ref: entry.ref,
+        property: {
+          ...entry.property,
+          name: `${options.namePrefix ?? ""}${entry.property.name}${options.nameSuffix ?? ""}`,
+          grossFloorArea: {
+            ...grossFloorArea,
+            ...(currentAsOf === undefined
+              ? {}
+              : {
+                  currentAsOf: new Date(`${currentAsOf}T00:00:00Z`),
+                }),
+          },
+        },
+      };
+    });
+    const total = imports.length;
+    for (const entry of imports) {
+      if (entry.property.name.length < 1 || entry.property.name.length > 80) {
+        throw new TypeError(
+          `Imported property name for ${entry.ref} must contain 1-80 characters`,
+        );
+      }
+    }
+
+    if (options.dryRun) {
+      return {
+        status: "dry-run",
+        properties: imports.map((entry) => ({
+          ref: entry.ref,
+          status: "planned",
+        })),
+      };
+    }
+
+    const results: IImportPropertyResult[] = [];
+    let completed = 0;
+
+    for (const entry of imports) {
+      try {
+        const property = await this.createProperty(
+          entry.property,
+          options.accountId,
+        );
+        results.push({ ref: entry.ref, status: "created", id: property.id });
+        completed++;
+        options.onProgress?.({
+          operation: "import",
+          propertyRef: entry.ref,
+          completed,
+          total,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        results.push({ ref: entry.ref, status: "failed", error: message });
+
+        if (!options.keepPartial) {
+          const created = results
+            .filter(
+              (result): result is IImportPropertyResult & { id: number } =>
+                result.status === "created" && result.id !== undefined,
+            )
+            .reverse();
+          let cleanupCompleted = 0;
+          for (const result of created) {
+            try {
+              await this.deleteProperty(result.id);
+              result.status = "rolled-back";
+            } catch (cleanupError) {
+              result.status = "cleanup-failed";
+              result.error =
+                cleanupError instanceof Error
+                  ? cleanupError.message
+                  : String(cleanupError);
+            }
+            cleanupCompleted++;
+            options.onProgress?.({
+              operation: "cleanup",
+              propertyRef: result.ref,
+              completed: cleanupCompleted,
+              total: created.length,
+            });
+          }
+        }
+
+        return { status: "failed", properties: results, error: message };
+      }
+    }
+
+    return { status: "complete", properties: results };
   }
 
   /**

--- a/src/PropertyBundle.spec.ts
+++ b/src/PropertyBundle.spec.ts
@@ -1,0 +1,574 @@
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { describe, expect, it } from "vitest";
+import { mockIProperty } from "./Mocks.js";
+import {
+  sanitizePropertyForBundle,
+  serializePropertyBundle,
+  validatePropertyBundle,
+} from "./PropertyBundle.js";
+import {
+  PROPERTY_BUNDLE_FORMAT,
+  PROPERTY_BUNDLE_SCHEMA,
+  PROPERTY_BUNDLE_SCHEMA_DOCUMENT,
+  PROPERTY_BUNDLE_VERSION,
+  type IPropertyBundleV1,
+} from "./types/index.js";
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const validateAgainstSchema = ajv.compile(PROPERTY_BUNDLE_SCHEMA_DOCUMENT);
+
+function bundle(): IPropertyBundleV1 {
+  return {
+    $schema: PROPERTY_BUNDLE_SCHEMA,
+    format: PROPERTY_BUNDLE_FORMAT,
+    formatVersion: PROPERTY_BUNDLE_VERSION,
+    capabilities: ["property"],
+    properties: [{ ref: "property:1", property: mockIProperty() }],
+  };
+}
+
+describe("property bundles", () => {
+  it("projects properties and nested values onto the portable allowlist", () => {
+    const property = {
+      ...mockIProperty(),
+      id: 123,
+      accessLevel: "Full",
+      audit: { createdBy: "user" },
+      grossFloorArea: {
+        value: 8000,
+        "@_units": "Square Feet",
+        "@_temporary": "false",
+        id: 456,
+        "@_default": "No",
+        audit: { createdBy: "user" },
+        currentAsOf: new Date("2026-08-05T12:34:56Z"),
+      },
+      irrigatedArea: {
+        value: 25,
+        units: "Square Feet",
+        default: "No",
+        id: 789,
+        audit: { createdBy: "user" },
+      },
+      address: { ...mockIProperty().address, responseOnly: true },
+      agency: {
+        id: 1,
+        code: "GSA",
+        name: "General Services Administration",
+        country: "US",
+        responseOnly: true,
+      },
+      responseOnly: true,
+    } as never;
+
+    expect(sanitizePropertyForBundle(property)).toEqual({
+      ...mockIProperty(),
+      grossFloorArea: {
+        ...mockIProperty().grossFloorArea,
+        "@_temporary": false,
+        currentAsOf: "2026-08-05",
+      },
+      irrigatedArea: {
+        value: 25,
+        units: "Square Feet",
+        default: false,
+      },
+      agency: {
+        id: 1,
+        code: "GSA",
+        name: "General Services Administration",
+        country: "US",
+      },
+    });
+  });
+
+  it("rejects malformed nested source values after projecting the allowlist", () => {
+    const property = {
+      ...mockIProperty(),
+      grossFloorArea: 8000,
+      irrigatedArea: 25,
+      address: "123 Main St",
+      agency: "GSA",
+      notes: undefined,
+      responseOnly: true,
+    } as never;
+
+    expect(() => sanitizePropertyForBundle(property)).toThrow(
+      "properties[0].property.grossFloorArea must be an object",
+    );
+  });
+
+  it("normalizes API string booleans and rejects unknown values", () => {
+    const truthy = sanitizePropertyForBundle({
+      ...mockIProperty(),
+      grossFloorArea: {
+        ...mockIProperty().grossFloorArea,
+        "@_temporary": "true",
+      },
+      irrigatedArea: { default: "Yes", units: "Acres", value: 25 },
+    } as never);
+    expect(truthy.grossFloorArea["@_temporary"]).toBe(true);
+    expect(truthy.irrigatedArea?.default).toBe(true);
+
+    const boolean = sanitizePropertyForBundle({
+      ...mockIProperty(),
+      grossFloorArea: {
+        ...mockIProperty().grossFloorArea,
+        "@_temporary": false,
+      },
+      irrigatedArea: { default: true, units: "Acres", value: 25 },
+    });
+    expect(boolean.grossFloorArea["@_temporary"]).toBe(false);
+    expect(boolean.irrigatedArea?.default).toBe(true);
+
+    expect(() =>
+      sanitizePropertyForBundle({
+        ...mockIProperty(),
+        grossFloorArea: {
+          ...mockIProperty().grossFloorArea,
+          "@_temporary": "sometimes",
+        },
+      } as never),
+    ).toThrow("grossFloorArea.@_temporary must be a boolean");
+  });
+
+  it("serializes fields canonically", () => {
+    const value = bundle();
+    const serialized = serializePropertyBundle(value, 0);
+
+    expect(serialized).toBe(
+      JSON.stringify({
+        $schema: PROPERTY_BUNDLE_SCHEMA,
+        capabilities: ["property"],
+        format: PROPERTY_BUNDLE_FORMAT,
+        formatVersion: PROPERTY_BUNDLE_VERSION,
+        properties: [
+          {
+            property: {
+              address: {
+                "@_address1": "123 Main St",
+                "@_city": "Test",
+                "@_country": "US",
+                "@_postalCode": "1234567",
+                "@_state": "NY",
+              },
+              constructionStatus: "Test",
+              grossFloorArea: {
+                "@_units": "Square Feet",
+                value: 8000,
+              },
+              isFederalProperty: false,
+              name: "Test Property",
+              occupancyPercentage: 80,
+              primaryFunction: "Data Center",
+              yearBuilt: 2022,
+            },
+            ref: "property:1",
+          },
+        ],
+      }),
+    );
+    expect(serializePropertyBundle(value)).toContain('\n  "$schema"');
+  });
+
+  it("rejects unsupported versions, duplicate refs, and response fields", () => {
+    expect(() =>
+      validatePropertyBundle({ ...bundle(), formatVersion: 2 }),
+    ).toThrow("Unsupported property bundle version: 2");
+    expect(() =>
+      validatePropertyBundle({
+        ...bundle(),
+        properties: [bundle().properties[0], bundle().properties[0]],
+      }),
+    ).toThrow("Duplicate property ref: property:1");
+    expect(() =>
+      validatePropertyBundle({
+        ...bundle(),
+        properties: [
+          {
+            ref: "property:1",
+            property: { ...mockIProperty(), id: 123 },
+          },
+        ],
+      }),
+    ).toThrow("has unknown field(s): id");
+    expect(() =>
+      validatePropertyBundle({
+        ...bundle(),
+        properties: [
+          {
+            ref: "property:1",
+            property: {
+              ...mockIProperty(),
+              grossFloorArea: {
+                ...mockIProperty().grossFloorArea,
+                audit: {},
+              },
+            },
+          },
+        ],
+      }),
+    ).toThrow("grossFloorArea has unknown field(s): audit");
+  });
+
+  it("rejects malformed bundle structure", () => {
+    const valid = bundle();
+    const cases: Array<[unknown, string]> = [
+      [null, "Property bundle must be an object"],
+      [
+        { ...valid, extra: true },
+        "Property bundle has unknown field(s): extra",
+      ],
+      [{ ...valid, $schema: "other" }, "Unsupported property bundle schema"],
+      [{ ...valid, format: "other" }, "Unsupported property bundle format"],
+      [{ ...valid, capabilities: "property" }, "capabilities"],
+      [{ ...valid, capabilities: [] }, "capabilities"],
+      [{ ...valid, capabilities: ["meter"] }, "capabilities"],
+      [{ ...valid, properties: "property" }, "at least one property"],
+      [{ ...valid, properties: [] }, "at least one property"],
+      [{ ...valid, properties: [null] }, "properties[0] must be an object"],
+      [
+        { ...valid, properties: [{ ...valid.properties[0], extra: true }] },
+        "properties[0] has unknown field(s): extra",
+      ],
+      [
+        { ...valid, properties: [{ ref: 1, property: mockIProperty() }] },
+        "ref must match",
+      ],
+      [
+        {
+          ...valid,
+          properties: [{ ref: "property:0", property: mockIProperty() }],
+        },
+        "ref must match",
+      ],
+      [
+        { ...valid, properties: [{ ref: "property:1", property: null }] },
+        "property must be an object",
+      ],
+      [
+        {
+          ...valid,
+          properties: [
+            {
+              ref: "property:1",
+              property: { ...mockIProperty(), name: undefined },
+            },
+          ],
+        },
+        "property.name is required",
+      ],
+    ];
+
+    for (const [value, message] of cases) {
+      expect(() => validatePropertyBundle(value)).toThrow(message);
+    }
+  });
+
+  it("rejects invalid property field types", () => {
+    const valid = bundle();
+    const withProperty = (property: unknown) => ({
+      ...valid,
+      properties: [{ ref: "property:1", property }],
+    });
+    const base = mockIProperty();
+    const cases: Array<[unknown, string]> = [
+      [{ ...base, name: 1 }, "name must contain"],
+      [{ ...base, name: "" }, "name must contain"],
+      [{ ...base, name: "x".repeat(81) }, "name must contain"],
+      [
+        { ...base, constructionStatus: 1 },
+        "constructionStatus must be Existing, Project, or Test",
+      ],
+      [
+        { ...base, constructionStatus: "Other" },
+        "constructionStatus must be Existing, Project, or Test",
+      ],
+      [
+        { ...base, primaryFunction: 1 },
+        "primaryFunction must be a non-empty string",
+      ],
+      [
+        { ...base, primaryFunction: "" },
+        "primaryFunction must be a non-empty string",
+      ],
+      [{ ...base, yearBuilt: "2022" }, "yearBuilt must be an integer"],
+      [{ ...base, yearBuilt: 2022.5 }, "yearBuilt must be an integer"],
+      [
+        { ...base, isFederalProperty: "false" },
+        "isFederalProperty must be a boolean",
+      ],
+      [
+        { ...base, occupancyPercentage: "80" },
+        "occupancyPercentage must be a multiple of 5",
+      ],
+      [
+        { ...base, occupancyPercentage: Number.POSITIVE_INFINITY },
+        "occupancyPercentage must be a multiple of 5",
+      ],
+      [
+        { ...base, occupancyPercentage: -5 },
+        "occupancyPercentage must be a multiple of 5",
+      ],
+      [
+        { ...base, occupancyPercentage: 105 },
+        "occupancyPercentage must be a multiple of 5",
+      ],
+      [
+        { ...base, occupancyPercentage: 82 },
+        "occupancyPercentage must be a multiple of 5",
+      ],
+      [{ ...base, grossFloorArea: 8000 }, "grossFloorArea must be an object"],
+      [{ ...base, address: "123 Main St" }, "address must be an object"],
+      [
+        { ...base, address: { ...base.address, extra: true } },
+        "address has unknown field(s): extra",
+      ],
+      [
+        { ...base, address: { ...base.address, "@_county": 1 } },
+        "address.@_county must be a string",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, "@_units": undefined },
+        },
+        "grossFloorArea.@_units must be Square Feet or Square Meters",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, "@_units": "Acres" },
+        },
+        "grossFloorArea.@_units must be Square Feet or Square Meters",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, "@_temporary": "false" },
+        },
+        "grossFloorArea.@_temporary must be a boolean",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, currentAsOf: 20260805 },
+        },
+        "grossFloorArea.currentAsOf must be a valid YYYY-MM-DD date",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, currentAsOf: "August 5" },
+        },
+        "grossFloorArea.currentAsOf must be a valid YYYY-MM-DD date",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, currentAsOf: "2026-02-30" },
+        },
+        "grossFloorArea.currentAsOf must be a valid YYYY-MM-DD date",
+      ],
+      [{ ...base, irrigatedArea: 25 }, "irrigatedArea must be an object"],
+      [
+        { ...base, irrigatedArea: { value: 25, extra: true } },
+        "irrigatedArea has unknown field(s): extra",
+      ],
+      [
+        { ...base, irrigatedArea: { value: 25 } },
+        "irrigatedArea.units must be Square Feet",
+      ],
+      [
+        { ...base, irrigatedArea: { units: "Yards", value: 25 } },
+        "irrigatedArea.units must be Square Feet",
+      ],
+      [
+        { ...base, irrigatedArea: { units: "Acres", value: "25" } },
+        "irrigatedArea.value must be a finite number or an empty string",
+      ],
+      [
+        { ...base, irrigatedArea: { units: "Acres", value: Number.NaN } },
+        "irrigatedArea.value must be a finite number or an empty string",
+      ],
+      [
+        {
+          ...base,
+          irrigatedArea: { default: "No", units: "Acres", value: 25 },
+        },
+        "irrigatedArea.default must be a boolean",
+      ],
+      [
+        { ...base, grossFloorArea: { ...base.grossFloorArea, value: "8000" } },
+        "grossFloorArea.value must be a finite number",
+      ],
+      [
+        {
+          ...base,
+          grossFloorArea: { ...base.grossFloorArea, value: Number.NaN },
+        },
+        "grossFloorArea.value must be a finite number",
+      ],
+      [
+        { ...base, address: { ...base.address, "@_country": 1 } },
+        "address.@_country must be a string",
+      ],
+      [
+        { ...base, numberOfBuildings: "2" },
+        "numberOfBuildings must be a finite number",
+      ],
+      [
+        { ...base, numberOfBuildings: Number.POSITIVE_INFINITY },
+        "numberOfBuildings must be a finite number",
+      ],
+      [{ ...base, federalOwner: 1 }, "federalOwner must be a string"],
+      [{ ...base, agency: "GSA" }, "agency must be an object"],
+      [
+        { ...base, agency: { id: 1, country: "US", extra: true } },
+        "agency has unknown field(s): extra",
+      ],
+      [
+        { ...base, agency: { id: "1", country: "US" } },
+        "agency.id must be an integer",
+      ],
+      [
+        { ...base, agency: { id: 1.5, country: "US" } },
+        "agency.id must be an integer",
+      ],
+      [
+        { ...base, agency: { id: 1, country: 1 } },
+        "agency.country must be a string",
+      ],
+      [
+        { ...base, agency: { id: 1, country: "US", code: 1 } },
+        "agency.code must be a string",
+      ],
+      [
+        { ...base, agencyDepartmentRegion: 1 },
+        "agencyDepartmentRegion must be a string",
+      ],
+      [
+        { ...base, isInstitutionalProperty: "false" },
+        "isInstitutionalProperty must be a boolean",
+      ],
+    ];
+
+    for (const [property, message] of cases) {
+      expect(() => validatePropertyBundle(withProperty(property))).toThrow(
+        message,
+      );
+    }
+
+    expect(() =>
+      validatePropertyBundle(
+        withProperty({
+          ...base,
+          grossFloorArea: {
+            ...base.grossFloorArea,
+            "@_temporary": false,
+            currentAsOf: "2026-08-05",
+          },
+          irrigatedArea: { default: false, units: "Acres", value: "" },
+          address: {
+            ...base.address,
+            "@_address2": "Suite 100",
+            "@_county": "Test County",
+            "@_otherState": "Other",
+          },
+          numberOfBuildings: 2,
+          federalOwner: "US",
+          agency: {
+            id: 1,
+            code: "GSA",
+            name: "General Services Administration",
+            country: "US",
+          },
+          agencyDepartmentRegion: "Region 1",
+          federalCampus: "Test Campus",
+          notes: "Portable fixture",
+          isInstitutionalProperty: false,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it("keeps the runtime validator in parity with the embedded schema", () => {
+    const valid = bundle();
+    const withProperty = (property: unknown) => ({
+      ...valid,
+      properties: [{ ref: "property:1", property }],
+    });
+    const base = mockIProperty();
+    const fixtures: Array<[string, unknown, boolean]> = [
+      ["minimal", valid, true],
+      [
+        "all portable fields",
+        withProperty({
+          ...base,
+          grossFloorArea: {
+            ...base.grossFloorArea,
+            "@_temporary": false,
+            currentAsOf: "2026-08-05",
+          },
+          irrigatedArea: { default: false, units: "Acres", value: "" },
+          numberOfBuildings: 2,
+          federalOwner: "US",
+          agency: { id: 1, code: "GSA", name: "GSA", country: "US" },
+          agencyDepartmentRegion: "Region 1",
+          federalCampus: "Test Campus",
+          notes: "Fixture",
+          isInstitutionalProperty: false,
+        }),
+        true,
+      ],
+      [
+        "construction status",
+        withProperty({ ...base, constructionStatus: "Other" }),
+        false,
+      ],
+      [
+        "agency required fields",
+        withProperty({ ...base, agency: { id: 1 } }),
+        false,
+      ],
+      [
+        "irrigated area value",
+        withProperty({
+          ...base,
+          irrigatedArea: { units: "Acres", value: "25" },
+        }),
+        false,
+      ],
+      [
+        "floor area date",
+        withProperty({
+          ...base,
+          grossFloorArea: {
+            ...base.grossFloorArea,
+            currentAsOf: "2026-02-30",
+          },
+        }),
+        false,
+      ],
+    ];
+
+    expect(PROPERTY_BUNDLE_SCHEMA_DOCUMENT.$id).toBe(PROPERTY_BUNDLE_SCHEMA);
+    expect(PROPERTY_BUNDLE_SCHEMA_DOCUMENT.properties.$schema.const).toBe(
+      PROPERTY_BUNDLE_SCHEMA,
+    );
+    for (const [name, value, expected] of fixtures) {
+      const schemaResult = validateAgainstSchema(value);
+      expect(
+        schemaResult,
+        `${name}: ${ajv.errorsText(validateAgainstSchema.errors)}`,
+      ).toBe(expected);
+      if (expected) {
+        expect(() => validatePropertyBundle(value), name).not.toThrow();
+      } else {
+        expect(() => validatePropertyBundle(value), name).toThrow();
+      }
+    }
+  });
+});

--- a/src/PropertyBundle.ts
+++ b/src/PropertyBundle.ts
@@ -1,0 +1,487 @@
+import {
+  PROPERTY_BUNDLE_FORMAT,
+  PROPERTY_BUNDLE_SCHEMA,
+  PROPERTY_BUNDLE_VERSION,
+  type IPropertyBundleV1,
+  type PortableProperty,
+} from "./types/index.js";
+import type { IClientProperty } from "./types/client/IClientProperty.js";
+import { isRecord } from "./types/xml/response/IResponse.js";
+
+const BUNDLE_KEYS = new Set([
+  "$schema",
+  "format",
+  "formatVersion",
+  "capabilities",
+  "properties",
+]);
+const ENTRY_KEYS = new Set(["ref", "property"]);
+const CONSTRUCTION_STATUSES = new Set(["Existing", "Project", "Test"]);
+const FLOOR_AREA_KEYS = new Set([
+  "@_units",
+  "@_temporary",
+  "currentAsOf",
+  "value",
+]);
+const FLOOR_AREA_UNITS = new Set(["Square Feet", "Square Meters"]);
+const IRRIGATED_AREA_KEYS = new Set(["default", "units", "value"]);
+const IRRIGATED_AREA_UNITS = new Set([
+  "Square Feet",
+  "Square Meters",
+  "Acres",
+  "",
+]);
+const AGENCY_KEYS = new Set(["id", "code", "name", "country"]);
+const ADDRESS_KEYS = new Set([
+  "@_address1",
+  "@_address2",
+  "@_city",
+  "@_county",
+  "@_postalCode",
+  "@_state",
+  "@_otherState",
+  "@_country",
+]);
+const REQUIRED_ADDRESS_KEYS = [
+  "@_address1",
+  "@_city",
+  "@_postalCode",
+  "@_country",
+] as const;
+const PROPERTY_KEYS = new Set([
+  "name",
+  "constructionStatus",
+  "primaryFunction",
+  "grossFloorArea",
+  "irrigatedArea",
+  "yearBuilt",
+  "address",
+  "numberOfBuildings",
+  "isFederalProperty",
+  "federalOwner",
+  "agency",
+  "agencyDepartmentRegion",
+  "federalCampus",
+  "occupancyPercentage",
+  "notes",
+  "isInstitutionalProperty",
+]);
+const REQUIRED_PROPERTY_KEYS = [
+  "name",
+  "constructionStatus",
+  "primaryFunction",
+  "grossFloorArea",
+  "yearBuilt",
+  "address",
+  "isFederalProperty",
+  "occupancyPercentage",
+] as const;
+
+function assertKnownKeys(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  path: string,
+): void {
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unknown.length > 0) {
+    throw new TypeError(`${path} has unknown field(s): ${unknown.join(", ")}`);
+  }
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value instanceof Date) {
+    return value.toISOString().slice(0, 10);
+  }
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)]),
+    );
+  }
+  return value;
+}
+
+function normalizeBoolean(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  switch (value.toLowerCase()) {
+    case "true":
+    case "yes":
+      return true;
+    case "false":
+    case "no":
+      return false;
+    default:
+      return value;
+  }
+}
+
+function isIsoDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return (
+    !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+  );
+}
+
+function assertPortableProperty(
+  property: unknown,
+): asserts property is PortableProperty {
+  validatePropertyBundle({
+    $schema: PROPERTY_BUNDLE_SCHEMA,
+    format: PROPERTY_BUNDLE_FORMAT,
+    formatVersion: PROPERTY_BUNDLE_VERSION,
+    capabilities: ["property"],
+    properties: [{ ref: "property:1", property }],
+  });
+}
+
+export function sanitizePropertyForBundle(
+  property: IClientProperty,
+): PortableProperty {
+  const grossFloorArea = isRecord(property.grossFloorArea)
+    ? {
+        "@_units": property.grossFloorArea["@_units"],
+        "@_temporary": normalizeBoolean(property.grossFloorArea["@_temporary"]),
+        currentAsOf: property.grossFloorArea.currentAsOf,
+        value: property.grossFloorArea.value,
+      }
+    : property.grossFloorArea;
+  const irrigatedArea = isRecord(property.irrigatedArea)
+    ? {
+        default: normalizeBoolean(property.irrigatedArea.default),
+        units: property.irrigatedArea.units,
+        value: property.irrigatedArea.value,
+      }
+    : property.irrigatedArea;
+  const address = isRecord(property.address)
+    ? {
+        "@_address1": property.address["@_address1"],
+        "@_address2": property.address["@_address2"],
+        "@_city": property.address["@_city"],
+        "@_county": property.address["@_county"],
+        "@_postalCode": property.address["@_postalCode"],
+        "@_state": property.address["@_state"],
+        "@_otherState": property.address["@_otherState"],
+        "@_country": property.address["@_country"],
+      }
+    : property.address;
+  const agency = isRecord(property.agency)
+    ? {
+        id: property.agency.id,
+        code: property.agency.code,
+        name: property.agency.name,
+        country: property.agency.country,
+      }
+    : property.agency;
+
+  const portable = canonicalize({
+    name: property.name,
+    constructionStatus: property.constructionStatus,
+    primaryFunction: property.primaryFunction,
+    grossFloorArea,
+    ...(irrigatedArea === undefined ? {} : { irrigatedArea }),
+    yearBuilt: property.yearBuilt,
+    address,
+    numberOfBuildings: property.numberOfBuildings,
+    isFederalProperty: property.isFederalProperty,
+    federalOwner: property.federalOwner,
+    agency,
+    agencyDepartmentRegion: property.agencyDepartmentRegion,
+    federalCampus: property.federalCampus,
+    occupancyPercentage: property.occupancyPercentage,
+    notes: property.notes,
+    isInstitutionalProperty: property.isInstitutionalProperty,
+  });
+  assertPortableProperty(portable);
+  return portable;
+}
+
+export function validatePropertyBundle(
+  value: unknown,
+): asserts value is IPropertyBundleV1 {
+  if (!isRecord(value)) {
+    throw new TypeError("Property bundle must be an object");
+  }
+  assertKnownKeys(value, BUNDLE_KEYS, "Property bundle");
+  if (value.$schema !== PROPERTY_BUNDLE_SCHEMA) {
+    throw new TypeError(`Unsupported property bundle schema: ${value.$schema}`);
+  }
+  if (value.format !== PROPERTY_BUNDLE_FORMAT) {
+    throw new TypeError(`Unsupported property bundle format: ${value.format}`);
+  }
+  if (value.formatVersion !== PROPERTY_BUNDLE_VERSION) {
+    throw new TypeError(
+      `Unsupported property bundle version: ${value.formatVersion}`,
+    );
+  }
+  if (
+    !Array.isArray(value.capabilities) ||
+    value.capabilities.length !== 1 ||
+    value.capabilities[0] !== "property"
+  ) {
+    throw new TypeError(
+      'Property bundle capabilities must currently be exactly ["property"]',
+    );
+  }
+  if (!Array.isArray(value.properties) || value.properties.length === 0) {
+    throw new TypeError("Property bundle must contain at least one property");
+  }
+
+  const refs = new Set<string>();
+  value.properties.forEach((entry, index) => {
+    const entryPath = `properties[${index}]`;
+    if (!isRecord(entry)) {
+      throw new TypeError(`${entryPath} must be an object`);
+    }
+    assertKnownKeys(entry, ENTRY_KEYS, entryPath);
+    if (
+      typeof entry.ref !== "string" ||
+      !/^property:[1-9]\d*$/.test(entry.ref)
+    ) {
+      throw new TypeError(`${entryPath}.ref must match property:<positive-id>`);
+    }
+    if (refs.has(entry.ref)) {
+      throw new TypeError(`Duplicate property ref: ${entry.ref}`);
+    }
+    refs.add(entry.ref);
+
+    if (!isRecord(entry.property)) {
+      throw new TypeError(`${entryPath}.property must be an object`);
+    }
+    assertKnownKeys(entry.property, PROPERTY_KEYS, `${entryPath}.property`);
+    for (const key of REQUIRED_PROPERTY_KEYS) {
+      if (entry.property[key] === undefined) {
+        throw new TypeError(`${entryPath}.property.${key} is required`);
+      }
+    }
+    if (
+      typeof entry.property.name !== "string" ||
+      entry.property.name.length === 0 ||
+      entry.property.name.length > 80
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.name must contain 1-80 characters`,
+      );
+    }
+    if (
+      typeof entry.property.constructionStatus !== "string" ||
+      !CONSTRUCTION_STATUSES.has(entry.property.constructionStatus)
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.constructionStatus must be Existing, Project, or Test`,
+      );
+    }
+    if (
+      typeof entry.property.primaryFunction !== "string" ||
+      entry.property.primaryFunction.length === 0
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.primaryFunction must be a non-empty string`,
+      );
+    }
+    if (
+      typeof entry.property.yearBuilt !== "number" ||
+      !Number.isInteger(entry.property.yearBuilt)
+    ) {
+      throw new TypeError(`${entryPath}.property.yearBuilt must be an integer`);
+    }
+    if (typeof entry.property.isFederalProperty !== "boolean") {
+      throw new TypeError(
+        `${entryPath}.property.isFederalProperty must be a boolean`,
+      );
+    }
+    if (
+      typeof entry.property.occupancyPercentage !== "number" ||
+      !Number.isFinite(entry.property.occupancyPercentage) ||
+      entry.property.occupancyPercentage < 0 ||
+      entry.property.occupancyPercentage > 100 ||
+      entry.property.occupancyPercentage % 5 !== 0
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.occupancyPercentage must be a multiple of 5 from 0 through 100`,
+      );
+    }
+    if (!isRecord(entry.property.grossFloorArea)) {
+      throw new TypeError(
+        `${entryPath}.property.grossFloorArea must be an object`,
+      );
+    }
+    if (!isRecord(entry.property.address)) {
+      throw new TypeError(`${entryPath}.property.address must be an object`);
+    }
+    assertKnownKeys(
+      entry.property.grossFloorArea,
+      FLOOR_AREA_KEYS,
+      `${entryPath}.property.grossFloorArea`,
+    );
+    assertKnownKeys(
+      entry.property.address,
+      ADDRESS_KEYS,
+      `${entryPath}.property.address`,
+    );
+    for (const key of REQUIRED_ADDRESS_KEYS) {
+      if (typeof entry.property.address[key] !== "string") {
+        throw new TypeError(
+          `${entryPath}.property.address.${key} must be a string`,
+        );
+      }
+    }
+    for (const key of ADDRESS_KEYS) {
+      const addressPart = entry.property.address[key];
+      if (addressPart !== undefined && typeof addressPart !== "string") {
+        throw new TypeError(
+          `${entryPath}.property.address.${key} must be a string`,
+        );
+      }
+    }
+    if (
+      typeof entry.property.grossFloorArea["@_units"] !== "string" ||
+      !FLOOR_AREA_UNITS.has(entry.property.grossFloorArea["@_units"])
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.grossFloorArea.@_units must be Square Feet or Square Meters`,
+      );
+    }
+    if (
+      entry.property.grossFloorArea["@_temporary"] !== undefined &&
+      typeof entry.property.grossFloorArea["@_temporary"] !== "boolean"
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.grossFloorArea.@_temporary must be a boolean`,
+      );
+    }
+    if (
+      entry.property.grossFloorArea.currentAsOf !== undefined &&
+      (typeof entry.property.grossFloorArea.currentAsOf !== "string" ||
+        !isIsoDate(entry.property.grossFloorArea.currentAsOf))
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.grossFloorArea.currentAsOf must be a valid YYYY-MM-DD date`,
+      );
+    }
+    if (entry.property.irrigatedArea !== undefined) {
+      if (!isRecord(entry.property.irrigatedArea)) {
+        throw new TypeError(
+          `${entryPath}.property.irrigatedArea must be an object`,
+        );
+      }
+      assertKnownKeys(
+        entry.property.irrigatedArea,
+        IRRIGATED_AREA_KEYS,
+        `${entryPath}.property.irrigatedArea`,
+      );
+      if (
+        typeof entry.property.irrigatedArea.units !== "string" ||
+        !IRRIGATED_AREA_UNITS.has(entry.property.irrigatedArea.units)
+      ) {
+        throw new TypeError(
+          `${entryPath}.property.irrigatedArea.units must be Square Feet, Square Meters, Acres, or an empty string`,
+        );
+      }
+      if (!(
+        (typeof entry.property.irrigatedArea.value === "number" &&
+          Number.isFinite(entry.property.irrigatedArea.value)) ||
+        entry.property.irrigatedArea.value === ""
+      )) {
+        throw new TypeError(
+          `${entryPath}.property.irrigatedArea.value must be a finite number or an empty string`,
+        );
+      }
+      if (
+        entry.property.irrigatedArea.default !== undefined &&
+        typeof entry.property.irrigatedArea.default !== "boolean"
+      ) {
+        throw new TypeError(
+          `${entryPath}.property.irrigatedArea.default must be a boolean`,
+        );
+      }
+    }
+    if (
+      typeof entry.property.grossFloorArea.value !== "number" ||
+      !Number.isFinite(entry.property.grossFloorArea.value)
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.grossFloorArea.value must be a finite number`,
+      );
+    }
+    if (
+      entry.property.numberOfBuildings !== undefined &&
+      (typeof entry.property.numberOfBuildings !== "number" ||
+        !Number.isFinite(entry.property.numberOfBuildings))
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.numberOfBuildings must be a finite number`,
+      );
+    }
+    if (
+      entry.property.federalOwner !== undefined &&
+      typeof entry.property.federalOwner !== "string"
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.federalOwner must be a string`,
+      );
+    }
+    if (entry.property.agency !== undefined) {
+      if (!isRecord(entry.property.agency)) {
+        throw new TypeError(`${entryPath}.property.agency must be an object`);
+      }
+      assertKnownKeys(
+        entry.property.agency,
+        AGENCY_KEYS,
+        `${entryPath}.property.agency`,
+      );
+      if (
+        typeof entry.property.agency.id !== "number" ||
+        !Number.isInteger(entry.property.agency.id)
+      ) {
+        throw new TypeError(
+          `${entryPath}.property.agency.id must be an integer`,
+        );
+      }
+      if (typeof entry.property.agency.country !== "string") {
+        throw new TypeError(
+          `${entryPath}.property.agency.country must be a string`,
+        );
+      }
+      for (const key of ["code", "name"] as const) {
+        const agencyPart = entry.property.agency[key];
+        if (agencyPart !== undefined && typeof agencyPart !== "string") {
+          throw new TypeError(
+            `${entryPath}.property.agency.${key} must be a string`,
+          );
+        }
+      }
+    }
+    for (const key of [
+      "agencyDepartmentRegion",
+      "federalCampus",
+      "notes",
+    ] as const) {
+      const propertyPart = entry.property[key];
+      if (propertyPart !== undefined && typeof propertyPart !== "string") {
+        throw new TypeError(`${entryPath}.property.${key} must be a string`);
+      }
+    }
+    if (
+      entry.property.isInstitutionalProperty !== undefined &&
+      typeof entry.property.isInstitutionalProperty !== "boolean"
+    ) {
+      throw new TypeError(
+        `${entryPath}.property.isInstitutionalProperty must be a boolean`,
+      );
+    }
+  });
+}
+
+export function serializePropertyBundle(
+  bundle: IPropertyBundleV1,
+  indent = 2,
+): string {
+  validatePropertyBundle(bundle);
+  return JSON.stringify(canonicalize(bundle), null, indent);
+}

--- a/src/cli/PortfolioManagerBaseCommand.ts
+++ b/src/cli/PortfolioManagerBaseCommand.ts
@@ -5,8 +5,8 @@ import { PortfolioManagerApi } from "../PortfolioManagerApi.js";
 import { isRecord } from "../types/xml/response/IResponse.js";
 
 export function parseIntArg(value: string): number {
-  const parsedValue = Number.parseInt(value, 10);
-  if (Number.isNaN(parsedValue)) {
+  const parsedValue = Number(value);
+  if (!/^[+-]?\d+$/.test(value) || !Number.isSafeInteger(parsedValue)) {
     throw new InvalidArgumentError(`Invalid integer: ${value}`);
   }
   return parsedValue;
@@ -136,6 +136,20 @@ export class PortfolioManagerBaseCommand extends Command {
       result.push(parent);
     }
     return result;
+  }
+
+  protected getResolvedIndent(): number {
+    const configuredCommand = this._getCommandAndParents().find((command) => {
+      const source = command.getOptionValueSource("indent");
+      return source !== undefined && source !== "default";
+    });
+    if (configuredCommand) {
+      return Number(configuredCommand.getOptionValue("indent"));
+    }
+    const indentOption = this.options.find(
+      (option) => option.long === "--indent",
+    )!;
+    return Number(indentOption.defaultValue);
   }
 
   protected async _action(): Promise<void> {

--- a/src/cli/PortfolioManagerCommand.spec.ts
+++ b/src/cli/PortfolioManagerCommand.spec.ts
@@ -17,7 +17,9 @@ describe("parseIntArg", () => {
   });
 
   it("throws InvalidArgumentError on invalid integers", () => {
-    expect(() => parseIntArg("abc")).to.throw(InvalidArgumentError);
+    for (const value of ["abc", "1.5", "10abc", "9007199254740992"]) {
+      expect(() => parseIntArg(value), value).to.throw(InvalidArgumentError);
+    }
   });
 });
 

--- a/src/cli/PortfolioManagerPropertyBundleCommand.spec.ts
+++ b/src/cli/PortfolioManagerPropertyBundleCommand.spec.ts
@@ -1,0 +1,210 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mockIProperty } from "../Mocks.js";
+import { serializePropertyBundle } from "../PropertyBundle.js";
+import {
+  setupCliHarness,
+  type CliHarness,
+} from "../test/cli/cliTestHarness.js";
+import {
+  PROPERTY_BUNDLE_FORMAT,
+  PROPERTY_BUNDLE_SCHEMA,
+  PROPERTY_BUNDLE_VERSION,
+} from "../types/index.js";
+
+describe("property import/export CLI commands", () => {
+  let harness: CliHarness;
+  let temporaryDirectory: string | undefined;
+
+  beforeEach(() => {
+    harness = setupCliHarness();
+  });
+
+  afterEach(async () => {
+    harness.restore();
+    if (temporaryDirectory) {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+      temporaryDirectory = undefined;
+    }
+  });
+
+  it("exports explicit property ids to stdout", async () => {
+    const bundle = {
+      $schema: PROPERTY_BUNDLE_SCHEMA,
+      capabilities: ["property"] as ["property"],
+      format: PROPERTY_BUNDLE_FORMAT,
+      formatVersion: PROPERTY_BUNDLE_VERSION,
+      properties: [{ ref: "property:1", property: mockIProperty() }],
+    };
+    harness.fakeClient.exportProperties.mockResolvedValueOnce(bundle);
+
+    await harness.parseCli(["property", "export", "--indent", "0", "20", "10"]);
+
+    expect(harness.fakeClient.exportProperties).toHaveBeenCalledWith([20, 10]);
+    expect(console.log).toHaveBeenCalledWith(
+      serializePropertyBundle(bundle, 0),
+    );
+  });
+
+  it("resolves --all through the accessible property list", async () => {
+    harness.fakeClient.getProperties.mockResolvedValueOnce([
+      { id: 3 },
+      { id: 4 },
+    ]);
+    harness.fakeClient.exportProperties.mockResolvedValueOnce({
+      $schema: PROPERTY_BUNDLE_SCHEMA,
+      format: PROPERTY_BUNDLE_FORMAT,
+      formatVersion: PROPERTY_BUNDLE_VERSION,
+      capabilities: ["property"],
+      properties: [{ ref: "property:1", property: mockIProperty() }],
+    });
+
+    await harness.parseCli(["property", "export", "--all"]);
+
+    expect(harness.fakeClient.exportProperties).toHaveBeenCalledWith([3, 4]);
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('\n  "$schema"'),
+    );
+  });
+
+  it("reports an empty accessible property list clearly", async () => {
+    harness.fakeClient.getProperties.mockResolvedValueOnce([]);
+
+    await expect(
+      harness.parseCli(["property", "export", "--all"]),
+    ).rejects.toThrow("No accessible properties found to export");
+    expect(harness.fakeClient.exportProperties).not.toHaveBeenCalled();
+  });
+
+  it("requires exactly one property selection mode", async () => {
+    await expect(harness.parseCli(["property", "export"])).rejects.toThrow(
+      "either one or more property ids or --all",
+    );
+    await expect(
+      harness.parseCli(["property", "export", "--all", "10"]),
+    ).rejects.toThrow("either one or more property ids or --all");
+  });
+
+  it("does not overwrite an export unless --force is provided", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pm-bundle-"));
+    const file = join(temporaryDirectory, "property.json");
+    await writeFile(file, "existing", "utf8");
+    const bundle = {
+      $schema: PROPERTY_BUNDLE_SCHEMA,
+      format: PROPERTY_BUNDLE_FORMAT,
+      formatVersion: PROPERTY_BUNDLE_VERSION,
+      capabilities: ["property"] as ["property"],
+      properties: [{ ref: "property:1", property: mockIProperty() }],
+    };
+    harness.fakeClient.exportProperties.mockResolvedValue(bundle);
+
+    await expect(
+      harness.parseCli(["property", "export", "--output", file, "10"]),
+    ).rejects.toMatchObject({ code: "EEXIST" });
+    await expect(readFile(file, "utf8")).resolves.toBe("existing");
+
+    await harness.parseCli([
+      "property",
+      "export",
+      "--output",
+      file,
+      "--force",
+      "10",
+    ]);
+    await expect(readFile(file, "utf8")).resolves.toContain(
+      PROPERTY_BUNDLE_FORMAT,
+    );
+  });
+
+  it("reads an import bundle and forwards safety options", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pm-bundle-"));
+    const file = join(temporaryDirectory, "property.json");
+    const bundle = { format: PROPERTY_BUNDLE_FORMAT, formatVersion: 1 };
+    await writeFile(file, JSON.stringify(bundle), "utf8");
+    harness.fakeClient.importProperties.mockResolvedValueOnce({
+      status: "dry-run",
+      properties: [],
+    });
+
+    await harness.parseCli([
+      "property",
+      "import",
+      file,
+      "--account-id",
+      "55",
+      "--dry-run",
+      "--keep-partial",
+      "--name-prefix",
+      "Copy ",
+    ]);
+
+    expect(harness.fakeClient.importProperties).toHaveBeenCalledWith(bundle, {
+      accountId: 55,
+      dryRun: true,
+      keepPartial: true,
+      namePrefix: "Copy ",
+      nameSuffix: undefined,
+    });
+  });
+
+  it("reads an import bundle from stdin and marks failed imports", async () => {
+    vi.spyOn(process, "stdin", "get").mockReturnValue(
+      Readable.from([
+        Buffer.from('{"format":"'),
+        `${PROPERTY_BUNDLE_FORMAT}"}`,
+      ]) as never,
+    );
+    harness.fakeClient.importProperties.mockResolvedValueOnce({
+      status: "failed",
+      error: "create failed",
+      properties: [],
+    });
+
+    await harness.parseCli(["property", "import", "-", "--indent", "2"]);
+
+    expect(harness.fakeClient.importProperties).toHaveBeenCalledWith(
+      { format: PROPERTY_BUNDLE_FORMAT },
+      expect.any(Object),
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          status: "failed",
+          error: "create failed",
+          properties: [],
+        },
+        null,
+        2,
+      ),
+    );
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("reports invalid JSON from files and non-Error parse failures", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "pm-bundle-"));
+    const file = join(temporaryDirectory, "property.json");
+    await writeFile(file, "not json", "utf8");
+
+    await expect(
+      harness.parseCli(["property", "import", file]),
+    ).rejects.toThrow(`Invalid JSON in ${file}`);
+
+    await writeFile(file, "{}", "utf8");
+    const parse = JSON.parse;
+    vi.spyOn(JSON, "parse").mockImplementation((raw: string) => {
+      if (raw === "{}") throw "parse failed";
+      return parse(raw) as unknown;
+    });
+    await expect(
+      harness.parseCli(["property", "import", file]),
+    ).rejects.toThrow("parse failed");
+  });
+
+  it("renders help for both commands", async () => {
+    await harness.parseCliHelp(["property", "export"]);
+    await harness.parseCliHelp(["property", "import"]);
+  });
+});

--- a/src/cli/PortfolioManagerPropertyCommand.ts
+++ b/src/cli/PortfolioManagerPropertyCommand.ts
@@ -1,10 +1,14 @@
 import { PortfolioManagerBaseCommand } from "./PortfolioManagerBaseCommand.js";
+import { PortfolioManagerPropertyExportCommand } from "./PortfolioManagerPropertyExportCommand.js";
+import { PortfolioManagerPropertyImportCommand } from "./PortfolioManagerPropertyImportCommand.js";
 import { PortfolioManagerPropertyListCommand } from "./PortfolioManagerPropertyListCommand.js";
 import { PortfolioManagerPropertyMetricsCommand } from "./PortfolioManagerPropertyMetricsCommand.js";
 
 export class PortfolioManagerPropertyCommand extends PortfolioManagerBaseCommand {
   constructor() {
     super("property");
+    this.addCommand(new PortfolioManagerPropertyExportCommand());
+    this.addCommand(new PortfolioManagerPropertyImportCommand());
     this.addCommand(new PortfolioManagerPropertyListCommand());
     this.addCommand(new PortfolioManagerPropertyMetricsCommand());
   }

--- a/src/cli/PortfolioManagerPropertyExportCommand.ts
+++ b/src/cli/PortfolioManagerPropertyExportCommand.ts
@@ -1,0 +1,64 @@
+import { writeFile } from "node:fs/promises";
+import { InvalidArgumentError } from "commander";
+import { serializePropertyBundle } from "../PropertyBundle.js";
+import {
+  parseIntArg,
+  PortfolioManagerBaseCommand,
+} from "./PortfolioManagerBaseCommand.js";
+
+export class PortfolioManagerPropertyExportCommand extends PortfolioManagerBaseCommand {
+  protected get examples() {
+    return [
+      `${this.getFullCommand()} --output property.json 123`,
+      `${this.getFullCommand()} --all --output portfolio.json`,
+      `${this.getFullCommand()} 123 | jq .`,
+    ];
+  }
+
+  constructor() {
+    super("export");
+    this.description("Export properties to a portable JSON bundle");
+    this.argument("[propertyIds...]", "Property ids to export");
+    this.option("--all", "Export all accessible properties", false);
+    this.option("-o, --output <file>", "Output file, or - for stdout", "-");
+    this.option("--force", "Overwrite an existing output file", false);
+    this.options.find((option) => option.long === "--indent")?.default(2);
+    this.addPortfolioManagerOptions();
+  }
+
+  protected async _action(): Promise<void> {
+    const options = this.opts<{
+      all: boolean;
+      output: string;
+      force: boolean;
+    }>();
+    const propertyIds = this.args.map((value) => parseIntArg(value));
+    const hasExplicitPropertyIds = propertyIds.length > 0;
+    if (options.all === hasExplicitPropertyIds) {
+      throw new InvalidArgumentError(
+        "Provide either one or more property ids or --all",
+      );
+    }
+
+    const client = this.getPortfolioManagerClient();
+    const ids = options.all
+      ? (await client.getProperties()).map((property) => property.id)
+      : propertyIds;
+    if (ids.length === 0) {
+      throw new InvalidArgumentError(
+        "No accessible properties found to export",
+      );
+    }
+    const bundle = await client.exportProperties(ids);
+    const json = serializePropertyBundle(bundle, this.getResolvedIndent());
+
+    if (options.output === "-") {
+      console.log(json);
+    } else {
+      await writeFile(options.output, `${json}\n`, {
+        encoding: "utf8",
+        flag: options.force ? "w" : "wx",
+      });
+    }
+  }
+}

--- a/src/cli/PortfolioManagerPropertyImportCommand.ts
+++ b/src/cli/PortfolioManagerPropertyImportCommand.ts
@@ -1,0 +1,84 @@
+import { readFile } from "node:fs/promises";
+import {
+  parseIntArg,
+  PortfolioManagerBaseCommand,
+} from "./PortfolioManagerBaseCommand.js";
+
+async function readStandardInput(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export class PortfolioManagerPropertyImportCommand extends PortfolioManagerBaseCommand {
+  protected get examples() {
+    return [
+      `${this.getFullCommand()} property.json --dry-run`,
+      `${this.getFullCommand()} property.json --account-id 456`,
+      `cat property.json | ${this.getFullCommand()} -`,
+    ];
+  }
+
+  constructor() {
+    super("import");
+    this.description("Import properties from a portable JSON bundle");
+    this.argument("<file>", "Input file, or - for stdin");
+    this.option(
+      "--account-id <id>",
+      "Target Portfolio Manager account id",
+      parseIntArg,
+    );
+    this.option(
+      "--dry-run",
+      "Validate and summarize without creating data",
+      false,
+    );
+    this.option(
+      "--keep-partial",
+      "Keep properties created before a failure",
+      false,
+    );
+    this.option("--name-prefix <prefix>", "Prefix imported property names");
+    this.option("--name-suffix <suffix>", "Suffix imported property names");
+    this.addPortfolioManagerOptions();
+  }
+
+  protected async _action(): Promise<void> {
+    const file = this.args[0];
+    const options = this.opts<{
+      accountId?: number;
+      dryRun: boolean;
+      keepPartial: boolean;
+      namePrefix?: string;
+      nameSuffix?: string;
+    }>();
+    const raw =
+      file === "-" ? await readStandardInput() : await readFile(file, "utf8");
+    let bundle: unknown;
+    try {
+      bundle = JSON.parse(raw) as unknown;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new TypeError(`Invalid JSON in ${file}: ${message}`, {
+        cause: error,
+      });
+    }
+
+    const result = await this.getPortfolioManagerClient().importProperties(
+      bundle,
+      {
+        accountId: options.accountId,
+        dryRun: options.dryRun,
+        keepPartial: options.keepPartial,
+        namePrefix: options.namePrefix,
+        nameSuffix: options.nameSuffix,
+      },
+    );
+    console.log(JSON.stringify(result, null, this.getResolvedIndent()));
+    if (result.status === "failed") {
+      process.exitCode = 1;
+    }
+  }
+}

--- a/src/cli/index.spec.ts
+++ b/src/cli/index.spec.ts
@@ -26,6 +26,8 @@ describe("cli index exports", () => {
       "PortfolioManagerMeterListLinksCommand",
       "PortfolioManagerNotificationsCommand",
       "PortfolioManagerPropertyCommand",
+      "PortfolioManagerPropertyExportCommand",
+      "PortfolioManagerPropertyImportCommand",
       "PortfolioManagerPropertyListCommand",
       "PortfolioManagerPropertyListEntitiesCommand",
       "PortfolioManagerPropertyListLinksCommand",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,8 @@ export * from "./PortfolioManagerMeterListEntitiesCommand.js";
 export * from "./PortfolioManagerMeterListLinksCommand.js";
 export * from "./PortfolioManagerNotificationsCommand.js";
 export * from "./PortfolioManagerPropertyCommand.js";
+export * from "./PortfolioManagerPropertyExportCommand.js";
+export * from "./PortfolioManagerPropertyImportCommand.js";
 export * from "./PortfolioManagerPropertyListCommand.js";
 export * from "./PortfolioManagerPropertyListEntitiesCommand.js";
 export * from "./PortfolioManagerPropertyListLinksCommand.js";

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -7,6 +7,14 @@ describe("library entrypoint", () => {
     expect(root.PortfolioManager).to.be.a("function");
     expect(root.PortfolioManagerApi).to.be.a("function");
     expect(root.PortfolioManagerApiError).to.be.a("function");
+    expect(root.validatePropertyBundle).to.be.a("function");
+    expect(root.serializePropertyBundle).to.be.a("function");
+    expect(root.PROPERTY_BUNDLE_FORMAT).to.equal(
+      "portfolio-manager/property-bundle",
+    );
+    expect(root.PROPERTY_BUNDLE_SCHEMA_DOCUMENT.$id).to.equal(
+      root.PROPERTY_BUNDLE_SCHEMA,
+    );
     // The CLI moved to the dedicated ./cli entry so SDK consumers no longer
     // load Commander and the command classes.
     expect(root).to.not.have.property("PortfolioManagerCommand");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./PortfolioManager.js";
 export * from "./PortfolioManagerApi.js";
+export * from "./PropertyBundle.js";
 export * from "./types/index.js";

--- a/src/schemas/property-bundle-v1.schema.json
+++ b/src/schemas/property-bundle-v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:portfolio-manager:property-bundle:v1",
+  "title": "Portfolio Manager portable property bundle v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "format",
+    "formatVersion",
+    "capabilities",
+    "properties"
+  ],
+  "properties": {
+    "$schema": { "const": "urn:portfolio-manager:property-bundle:v1" },
+    "format": { "const": "portfolio-manager/property-bundle" },
+    "formatVersion": { "const": 1 },
+    "capabilities": {
+      "type": "array",
+      "prefixItems": [{ "const": "property" }],
+      "items": false,
+      "minItems": 1,
+      "maxItems": 1
+    },
+    "properties": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/propertyEntry" }
+    }
+  },
+  "$defs": {
+    "floorArea": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["@_units", "value"],
+      "properties": {
+        "@_units": { "enum": ["Square Feet", "Square Meters"] },
+        "@_temporary": { "type": "boolean" },
+        "currentAsOf": { "type": "string", "format": "date" },
+        "value": { "type": "number" }
+      }
+    },
+    "address": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["@_address1", "@_city", "@_postalCode", "@_country"],
+      "properties": {
+        "@_address1": { "type": "string" },
+        "@_address2": { "type": "string" },
+        "@_city": { "type": "string" },
+        "@_county": { "type": "string" },
+        "@_postalCode": { "type": "string" },
+        "@_state": { "type": "string" },
+        "@_otherState": { "type": "string" },
+        "@_country": { "type": "string" }
+      }
+    },
+    "irrigatedArea": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["units", "value"],
+      "properties": {
+        "default": { "type": "boolean" },
+        "units": {
+          "enum": ["Square Feet", "Square Meters", "Acres", ""]
+        },
+        "value": {
+          "anyOf": [{ "type": "number" }, { "const": "" }]
+        }
+      }
+    },
+    "property": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "constructionStatus",
+        "primaryFunction",
+        "grossFloorArea",
+        "yearBuilt",
+        "address",
+        "isFederalProperty",
+        "occupancyPercentage"
+      ],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 80 },
+        "constructionStatus": {
+          "enum": ["Existing", "Project", "Test"]
+        },
+        "primaryFunction": { "type": "string", "minLength": 1 },
+        "grossFloorArea": { "$ref": "#/$defs/floorArea" },
+        "irrigatedArea": { "$ref": "#/$defs/irrigatedArea" },
+        "yearBuilt": { "type": "integer" },
+        "address": { "$ref": "#/$defs/address" },
+        "numberOfBuildings": { "type": "number" },
+        "isFederalProperty": { "type": "boolean" },
+        "federalOwner": { "type": "string" },
+        "agency": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "country"],
+          "properties": {
+            "id": { "type": "integer" },
+            "code": { "type": "string" },
+            "name": { "type": "string" },
+            "country": { "type": "string" }
+          }
+        },
+        "agencyDepartmentRegion": { "type": "string" },
+        "federalCampus": { "type": "string" },
+        "occupancyPercentage": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100,
+          "multipleOf": 5
+        },
+        "notes": { "type": "string" },
+        "isInstitutionalProperty": { "type": "boolean" }
+      }
+    },
+    "propertyEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "property"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "pattern": "^property:[1-9][0-9]*$"
+        },
+        "property": { "$ref": "#/$defs/property" }
+      }
+    }
+  }
+}

--- a/src/test/cli/cliTestHarness.ts
+++ b/src/test/cli/cliTestHarness.ts
@@ -41,6 +41,8 @@ export type FakeClient = {
   getChangedPropertyIds: ReturnType<typeof vi.fn>;
   getChangedPropertyUseIds: ReturnType<typeof vi.fn>;
   getChangedMeterIds: ReturnType<typeof vi.fn>;
+  exportProperties: ReturnType<typeof vi.fn>;
+  importProperties: ReturnType<typeof vi.fn>;
 };
 
 export function createFakeClient(): FakeClient {
@@ -73,6 +75,8 @@ export function createFakeClient(): FakeClient {
     getChangedPropertyIds: vi.fn(),
     getChangedPropertyUseIds: vi.fn(),
     getChangedMeterIds: vi.fn(),
+    exportProperties: vi.fn(),
+    importProperties: vi.fn(),
   };
 }
 

--- a/src/types/client/IPropertyBundle.ts
+++ b/src/types/client/IPropertyBundle.ts
@@ -1,0 +1,95 @@
+import type { IProperty } from "../xml/index.js";
+import propertyBundleV1Schema from "../../schemas/property-bundle-v1.schema.json" with { type: "json" };
+
+export const PROPERTY_BUNDLE_FORMAT = "portfolio-manager/property-bundle";
+export const PROPERTY_BUNDLE_VERSION = 1;
+export const PROPERTY_BUNDLE_SCHEMA =
+  "urn:portfolio-manager:property-bundle:v1";
+export const PROPERTY_BUNDLE_SCHEMA_DOCUMENT = Object.freeze(
+  propertyBundleV1Schema,
+);
+
+export type PropertyBundleCapability = "property";
+
+export interface PortableGrossFloorArea {
+  "@_units": "Square Feet" | "Square Meters";
+  "@_temporary"?: boolean;
+  currentAsOf?: string;
+  value: number;
+}
+
+export interface PortableIrrigatedArea {
+  default?: boolean;
+  units: "Square Feet" | "Square Meters" | "Acres" | "";
+  value: number | "";
+}
+
+export interface PortableProperty {
+  name: IProperty["name"];
+  constructionStatus: IProperty["constructionStatus"];
+  primaryFunction: IProperty["primaryFunction"];
+  grossFloorArea: PortableGrossFloorArea;
+  irrigatedArea?: PortableIrrigatedArea;
+  yearBuilt: IProperty["yearBuilt"];
+  address: IProperty["address"];
+  numberOfBuildings?: IProperty["numberOfBuildings"];
+  isFederalProperty: IProperty["isFederalProperty"];
+  federalOwner?: IProperty["federalOwner"];
+  agency?: IProperty["agency"];
+  agencyDepartmentRegion?: IProperty["agencyDepartmentRegion"];
+  federalCampus?: IProperty["federalCampus"];
+  occupancyPercentage: IProperty["occupancyPercentage"];
+  notes?: IProperty["notes"];
+  isInstitutionalProperty?: IProperty["isInstitutionalProperty"];
+}
+
+export interface IPropertyBundleEntryV1 {
+  ref: string;
+  property: PortableProperty;
+}
+
+export interface IPropertyBundleV1 {
+  $schema: typeof PROPERTY_BUNDLE_SCHEMA;
+  format: typeof PROPERTY_BUNDLE_FORMAT;
+  formatVersion: typeof PROPERTY_BUNDLE_VERSION;
+  capabilities: ["property"];
+  properties: IPropertyBundleEntryV1[];
+}
+
+export type IPropertyBundle = IPropertyBundleV1;
+
+export interface IPropertyBundleProgress {
+  operation: "export" | "import" | "cleanup";
+  propertyRef: string;
+  completed: number;
+  total: number;
+}
+
+export interface IExportPropertiesOptions {
+  onProgress?: (event: IPropertyBundleProgress) => void;
+}
+
+export interface IImportPropertiesOptions {
+  accountId?: number;
+  dryRun?: boolean;
+  keepPartial?: boolean;
+  namePrefix?: string;
+  nameSuffix?: string;
+  onProgress?: (event: IPropertyBundleProgress) => void;
+}
+
+export type ImportPropertyStatus =
+  "planned" | "created" | "failed" | "rolled-back" | "cleanup-failed";
+
+export interface IImportPropertyResult {
+  ref: string;
+  status: ImportPropertyStatus;
+  id?: number;
+  error?: string;
+}
+
+export interface IImportPropertiesResult {
+  status: "dry-run" | "complete" | "failed";
+  properties: IImportPropertyResult[];
+  error?: string;
+}

--- a/src/types/client/index.ts
+++ b/src/types/client/index.ts
@@ -7,3 +7,4 @@ export * from "./IClientPendingConnectionRequest.js";
 export * from "./IClientPendingShareRequest.js";
 export * from "./IClientProperty.js";
 export * from "./ICustomer.js";
+export * from "./IPropertyBundle.js";


### PR DESCRIPTION
## Summary

- add a versioned, deterministic JSON bundle format and published JSON Schema for portable core property data
- add SDK export/import methods with target-account selection, dry runs, progress reporting, name modifiers, and best-effort cleanup
- add `property export` and `property import` CLI commands with stdin/stdout support and safe file overwrite behavior
- document the core-only preview and export the new public SDK and CLI surfaces

## Scope

This first slice intentionally covers core property fields only. Property uses, meters, consumption, identifiers, and associations remain follow-up capabilities.

## Validation

- `npm run format:check`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- focused property-bundle suite: 25 passed
- new bundle and CLI files: 100% statements, branches, functions, and lines
- GitHub CI: all Node matrix checks, live coverage tests, and live-environment tests passed

The full local `npm test` command reaches the repository's credential-gated `PortfolioManager.spec.ts`; without credentials its only failure was the expected missing `PM_USERNAME`/`PM_PASSWORD` guard. The credentialed GitHub live-test job passed.
