### PR TITLE
ci: restrict workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches: [main, next]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # One CI run at a time per ref. Never cancel an active run: credentialed E2E
 # jobs mutate shared state and must reach their cleanup hooks. GitHub may still
 # replace an older pending run when a newer commit arrives.

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -6,6 +6,9 @@ on:
     - cron: "43 10 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # Live E2E tests mutate persistent fixtures. Never overlap them.
 concurrency:
   group: espm-live-e2e

--- a/.github/workflows/wstest-e2e.yml
+++ b/.github/workflows/wstest-e2e.yml
@@ -8,6 +8,9 @@ on:
     - cron: "17 6 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # The provider/peer test accounts are a shared singleton; runs must serialize.
 concurrency:
   group: espm-wstest-e2e


### PR DESCRIPTION
## Summary

- add workflow-level `contents: read` permissions to CI
- add the same least-privilege permissions to the scheduled Live E2E workflow
- add the same least-privilege permissions to the scheduled WSTest E2E workflow
- retain the existing job-specific write permissions for the release job

## Why

CodeQL reported `actions/missing-workflow-permissions` because jobs without an explicit permissions block inherit the repository’s default `GITHUB_TOKEN` permissions. Declaring the minimum required read permission prevents an unrelated repository-setting change from silently granting broader access.

## Impact

Routine checks and E2E jobs receive read-only repository contents access. The release job continues to use its existing explicit write permissions for releases, issue and pull-request comments, and npm trusted publishing.

## Validation

- compared the branch against `next`
- confirmed the diff contains only three workflow files
- confirmed each file adds only `permissions: contents: read`
- branch is based on the current `next` head after PR #77