### PR TITLE
feat!: require Node.js 22.22.2 or newer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20", "22", "lts/*", "latest"]
+        node-version: ["22.22.2", "lts/*", "latest"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["22.22.2", "lts/*", "latest"]
+        node-version: ["22", "lts/*", "latest"]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for contributing to `portfolio-manager`.
 
 ## Prerequisites
 
-- Node.js `>=20.19.0`
+- Node.js `>=22.22.2`
 - npm (uses lockfile; prefer `npm ci`)
 - Portfolio Manager credentials for integration tests
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Node.js SDK makes the platform more accessible to JavaScript developers.
 
 ## Runtime and Packaging
 
-- Node.js: `>=20.19.0`
+- Node.js: `>=22.22.2`
 - Package format: ESM-only (`"type": "module"`)
 - CLI bin entry: `dist/cli.js`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.22.2"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-semantic-release",
   "description": "Unofficial CLI Tool and SDK for Energy Star Portfolio Manager",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.22.2"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
## Summary

- raise the minimum supported Node.js version from 20.19.0 to 22.22.2
- update the documented development requirements and CI matrix
- refresh the lockfile metadata for the new engine floor

## Why

Node.js 20 reached end of life on April 30, 2026. Node.js 22.22.2 is the oldest active-LTS release accepted by npm 12.

Testing npm 12.0.2 confirmed that it still bundles the vulnerable `ip-address@10.2.0` and `undici@6.27.0` versions, so this PR does not add the unsupported semantic-release npm override; it would close none of the six Dependabot alerts.

## Impact

This is a breaking change for consumers and contributors running Node.js 20. Node.js 22.22.2 or newer is now required.

## Validation

- install on Node.js 22.22.2
- lint
- formatting
- typecheck
- build
- CLI smoke test
- tests: 176 passed, 14 skipped
- credentialed integration suite not run locally because `PM_USERNAME` and `PM_PASSWORD` are provided by CI
